### PR TITLE
[Refactor] Move shared types to oneil_shared

### DIFF
--- a/src-rs/oneil_ast/src/expression.rs
+++ b/src-rs/oneil_ast/src/expression.rs
@@ -1,5 +1,6 @@
 //! Expression constructs for the AST
 
+pub use oneil_shared::expr_ops::{BinaryOp, ComparisonOp, Literal, UnaryOp};
 use oneil_shared::span::Span;
 
 use crate::{naming::IdentifierNode, node::Node};
@@ -114,187 +115,14 @@ impl Expr {
     }
 }
 
-/// Comparison operators for expressions
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ComparisonOp {
-    /// Less than comparison (<)
-    LessThan,
-    /// Less than or equal comparison (<=)
-    LessThanEq,
-    /// Greater than comparison (>)
-    GreaterThan,
-    /// Greater than or equal comparison (>=)
-    GreaterThanEq,
-    /// Equality comparison (==)
-    Eq,
-    /// Inequality comparison (!=)
-    NotEq,
-}
-
 /// A node containing a comparison operator
 pub type ComparisonOpNode = Node<ComparisonOp>;
-
-impl ComparisonOp {
-    /// Creates a less than operator
-    #[must_use]
-    pub const fn less_than() -> Self {
-        Self::LessThan
-    }
-
-    /// Creates a less than or equal operator
-    #[must_use]
-    pub const fn less_than_eq() -> Self {
-        Self::LessThanEq
-    }
-
-    /// Creates a greater than operator
-    #[must_use]
-    pub const fn greater_than() -> Self {
-        Self::GreaterThan
-    }
-
-    /// Creates a greater than or equal operator
-    #[must_use]
-    pub const fn greater_than_eq() -> Self {
-        Self::GreaterThanEq
-    }
-
-    /// Creates an equality operator
-    #[must_use]
-    pub const fn eq() -> Self {
-        Self::Eq
-    }
-
-    /// Creates an inequality operator
-    #[must_use]
-    pub const fn not_eq() -> Self {
-        Self::NotEq
-    }
-}
-
-/// Binary operators for expressions
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BinaryOp {
-    /// Addition operator (+)
-    Add,
-    /// Subtraction operator (-)
-    Sub,
-    /// Escaped subtraction operator (--)
-    EscapedSub,
-    /// Multiplication operator (*)
-    Mul,
-    /// Division operator (/)
-    Div,
-    /// Escaped division operator (//)
-    EscapedDiv,
-    /// Modulo operator (%)
-    Mod,
-    /// Power operator (**)
-    Pow,
-    /// Logical AND operator (&&)
-    And,
-    /// Logical OR operator (||)
-    Or,
-    /// Min/max operator (min/max)
-    MinMax,
-}
 
 /// A node containing a binary operator
 pub type BinaryOpNode = Node<BinaryOp>;
 
-impl BinaryOp {
-    /// Creates an addition operator
-    #[must_use]
-    pub const fn add() -> Self {
-        Self::Add
-    }
-
-    /// Creates a subtraction operator
-    #[must_use]
-    pub const fn sub() -> Self {
-        Self::Sub
-    }
-
-    /// Creates an escaped subtraction operator
-    #[must_use]
-    pub const fn escaped_sub() -> Self {
-        Self::EscapedSub
-    }
-
-    /// Creates a multiplication operator
-    #[must_use]
-    pub const fn mul() -> Self {
-        Self::Mul
-    }
-
-    /// Creates a division operator
-    #[must_use]
-    pub const fn div() -> Self {
-        Self::Div
-    }
-
-    /// Creates an escaped division operator
-    #[must_use]
-    pub const fn escaped_div() -> Self {
-        Self::EscapedDiv
-    }
-
-    /// Creates a modulo operator
-    #[must_use]
-    pub const fn modulo() -> Self {
-        Self::Mod
-    }
-
-    /// Creates a power operator
-    #[must_use]
-    pub const fn pow() -> Self {
-        Self::Pow
-    }
-
-    /// Creates a logical AND operator
-    #[must_use]
-    pub const fn and() -> Self {
-        Self::And
-    }
-
-    /// Creates a logical OR operator
-    #[must_use]
-    pub const fn or() -> Self {
-        Self::Or
-    }
-
-    /// Creates a min/max operator
-    #[must_use]
-    pub const fn min_max() -> Self {
-        Self::MinMax
-    }
-}
-
-/// Unary operators for expressions
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum UnaryOp {
-    /// Negation operator (-)
-    Neg,
-    /// Logical NOT operator (!)
-    Not,
-}
-
 /// A node containing a unary operator
 pub type UnaryOpNode = Node<UnaryOp>;
-
-impl UnaryOp {
-    /// Creates a negation operator
-    #[must_use]
-    pub const fn neg() -> Self {
-        Self::Neg
-    }
-
-    /// Creates a logical NOT operator
-    #[must_use]
-    pub const fn not() -> Self {
-        Self::Not
-    }
-}
 
 /// Variable references in expressions
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -335,39 +163,8 @@ impl Variable {
     }
 }
 
-/// Literal values in expressions
-#[derive(Debug, Clone, PartialEq)]
-pub enum Literal {
-    /// Numeric literal value
-    Number(f64),
-    /// String literal value
-    String(String),
-    /// Boolean literal value
-    Boolean(bool),
-}
-
 /// A node containing a literal value
 pub type LiteralNode = Node<Literal>;
-
-impl Literal {
-    /// Creates a numeric literal
-    #[must_use]
-    pub const fn number(num: f64) -> Self {
-        Self::Number(num)
-    }
-
-    /// Creates a string literal
-    #[must_use]
-    pub const fn string(str: String) -> Self {
-        Self::String(str)
-    }
-
-    /// Creates a boolean literal
-    #[must_use]
-    pub const fn boolean(bool: bool) -> Self {
-        Self::Boolean(bool)
-    }
-}
 
 #[expect(
     unused_variables,

--- a/src-rs/oneil_ast/src/naming.rs
+++ b/src-rs/oneil_ast/src/naming.rs
@@ -1,60 +1,14 @@
 //! Naming constructs for the AST
 
-use crate::node::Node;
+pub use oneil_shared::naming::{Identifier, Label};
 
-/// An identifier in the Oneil language
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Identifier(String);
+use crate::node::Node;
 
 /// A node containing an identifier
 pub type IdentifierNode = Node<Identifier>;
 
-impl Identifier {
-    /// Creates a new identifier with the given string value
-    #[must_use]
-    pub const fn new(value: String) -> Self {
-        Self(value)
-    }
-
-    /// Returns the identifier as a string slice
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl From<String> for Identifier {
-    fn from(value: String) -> Self {
-        Self::new(value)
-    }
-}
-
-/// A label in the Oneil language
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Label(String);
-
 /// A node containing a label
 pub type LabelNode = Node<Label>;
-
-impl Label {
-    /// Creates a new label with the given string value
-    #[must_use]
-    pub const fn new(value: String) -> Self {
-        Self(value)
-    }
-
-    /// Returns the label as a string slice
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl From<String> for Label {
-    fn from(value: String) -> Self {
-        Self::new(value)
-    }
-}
 
 /// A directory name in the Oneil language
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src-rs/oneil_ir/src/expr.rs
+++ b/src-rs/oneil_ir/src/expr.rs
@@ -1,5 +1,6 @@
 //! Expression system for mathematical and logical operations in Oneil.
 
+pub use oneil_shared::expr_ops::{BinaryOp, ComparisonOp, Literal, UnaryOp};
 use oneil_shared::span::Span;
 
 use crate::{
@@ -275,99 +276,6 @@ impl Expr {
     }
 }
 
-/// Binary operators for mathematical and logical operations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BinaryOp {
-    /// Addition: `a + b`
-    Add,
-    /// Subtraction: `a - b`
-    Sub,
-    /// Escaped subtraction: `a -- b`
-    EscapedSub,
-    /// Multiplication: `a * b`
-    Mul,
-    /// Division: `a / b`
-    Div,
-    /// Escaped division: `a // b`
-    EscapedDiv,
-    /// Modulo: `a % b`
-    Mod,
-    /// Exponentiation: `a ^ b`
-    Pow,
-    /// Logical AND: `a && b`
-    And,
-    /// Logical OR: `a || b`
-    Or,
-    /// Minimum/maximum: `a | b`
-    MinMax,
-}
-
-/// Comparison operators for expressions.
-///
-/// Comparison operations support chaining for expressions like `a < b < c`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ComparisonOp {
-    /// Less than comparison: `a < b`
-    LessThan,
-    /// Less than or equal comparison: `a <= b`
-    LessThanEq,
-    /// Greater than comparison: `a > b`
-    GreaterThan,
-    /// Greater than or equal comparison: `a >= b`
-    GreaterThanEq,
-    /// Equality comparison: `a == b`
-    Eq,
-    /// Inequality comparison: `a != b`
-    NotEq,
-}
-
-impl ComparisonOp {
-    /// Creates a less than operator.
-    #[must_use]
-    pub const fn less_than() -> Self {
-        Self::LessThan
-    }
-
-    /// Creates a less than or equal operator.
-    #[must_use]
-    pub const fn less_than_eq() -> Self {
-        Self::LessThanEq
-    }
-
-    /// Creates a greater than operator.
-    #[must_use]
-    pub const fn greater_than() -> Self {
-        Self::GreaterThan
-    }
-
-    /// Creates a greater than or equal operator.
-    #[must_use]
-    pub const fn greater_than_eq() -> Self {
-        Self::GreaterThanEq
-    }
-
-    /// Creates an equality operator.
-    #[must_use]
-    pub const fn eq() -> Self {
-        Self::Eq
-    }
-
-    /// Creates an inequality operator.
-    #[must_use]
-    pub const fn not_eq() -> Self {
-        Self::NotEq
-    }
-}
-
-/// Unary operators for single-operand operations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum UnaryOp {
-    /// Negation: `-a`
-    Neg,
-    /// Logical NOT: `!a`
-    Not,
-}
-
 /// Function names for built-in and imported functions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FunctionName {
@@ -466,37 +374,6 @@ impl Variable {
             parameter_name,
             parameter_span,
         }
-    }
-}
-
-/// Literal values that can appear in expressions.
-#[derive(Debug, Clone, PartialEq)]
-pub enum Literal {
-    /// Numeric literal (floating-point).
-    Number(f64),
-    /// String literal.
-    String(String),
-    /// Boolean literal.
-    Boolean(bool),
-}
-
-impl Literal {
-    /// Creates a numeric literal.
-    #[must_use]
-    pub const fn number(value: f64) -> Self {
-        Self::Number(value)
-    }
-
-    /// Creates a string literal.
-    #[must_use]
-    pub const fn string(value: String) -> Self {
-        Self::String(value)
-    }
-
-    /// Creates a boolean literal.
-    #[must_use]
-    pub const fn boolean(value: bool) -> Self {
-        Self::Boolean(value)
     }
 }
 

--- a/src-rs/oneil_ir/src/parameter.rs
+++ b/src-rs/oneil_ir/src/parameter.rs
@@ -26,23 +26,7 @@ impl ParameterName {
     }
 }
 
-/// A label for a parameter.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Label(String);
-
-impl Label {
-    /// Creates a new label with the given name.
-    #[must_use]
-    pub const fn new(name: String) -> Self {
-        Self(name)
-    }
-
-    /// Returns the label as a string slice.
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
+pub use oneil_shared::naming::Label;
 
 /// Represents a single parameter in an Oneil model.
 #[derive(Debug, Clone, PartialEq)]

--- a/src-rs/oneil_ir/src/reference.rs
+++ b/src-rs/oneil_ir/src/reference.rs
@@ -1,24 +1,8 @@
 //! Reference types for identifiers, paths, and imports in Oneil.
 
+pub use oneil_shared::naming::Identifier;
+
 use std::path::{Path, PathBuf};
-
-/// An identifier for a variable, parameter, or other named entity in Oneil.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Identifier(String);
-
-impl Identifier {
-    /// Creates a new identifier from a string or string-like type.
-    #[must_use]
-    pub const fn new(identifier: String) -> Self {
-        Self(identifier)
-    }
-
-    /// Returns the string value of this identifier.
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
 
 /// A path to an Oneil model file.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src-rs/oneil_parser/src/expression.rs
+++ b/src-rs/oneil_parser/src/expression.rs
@@ -342,21 +342,21 @@ fn primary_expr(input: InputSpan<'_>) -> Result<'_, ExprNode, ParserError> {
             let parse_result = n.lexeme_str.parse::<f64>();
             let parse_result = parse_result.expect("all valid numbers should parse correctly");
 
-            let literal_node = n.into_node_with_value(Literal::number(parse_result));
+            let literal_node = n.into_node_with_value(Literal::Number(parse_result));
             literal_node.wrap(Expr::literal)
         }),
         map(string.convert_errors(), |s| {
             // trim quotes from the string
             let s_contents = s.lexeme_str[1..s.lexeme_str.len() - 1].to_string();
-            let literal_node = s.into_node_with_value(Literal::string(s_contents));
+            let literal_node = s.into_node_with_value(Literal::String(s_contents));
             literal_node.wrap(Expr::literal)
         }),
         map(true_.convert_errors(), |t| {
-            let literal_node = t.into_node_with_value(Literal::boolean(true));
+            let literal_node = t.into_node_with_value(Literal::Boolean(true));
             literal_node.wrap(Expr::literal)
         }),
         map(false_.convert_errors(), |t| {
-            let literal_node = t.into_node_with_value(Literal::boolean(false));
+            let literal_node = t.into_node_with_value(Literal::Boolean(false));
             literal_node.wrap(Expr::literal)
         }),
         function_call,

--- a/src-rs/oneil_resolver/src/resolver/resolve_expr.rs
+++ b/src-rs/oneil_resolver/src/resolver/resolve_expr.rs
@@ -166,41 +166,19 @@ where
     resolve_expr(expr, resolution_context)
 }
 
-/// Converts an AST comparison operation to a model comparison operation.
+/// Extracts the comparison operator from an AST node.
 fn resolve_comparison_op(op: &ast::ComparisonOpNode) -> ir::ComparisonOp {
-    match &**op {
-        ast::ComparisonOp::LessThan => ir::ComparisonOp::LessThan,
-        ast::ComparisonOp::LessThanEq => ir::ComparisonOp::LessThanEq,
-        ast::ComparisonOp::GreaterThan => ir::ComparisonOp::GreaterThan,
-        ast::ComparisonOp::GreaterThanEq => ir::ComparisonOp::GreaterThanEq,
-        ast::ComparisonOp::Eq => ir::ComparisonOp::Eq,
-        ast::ComparisonOp::NotEq => ir::ComparisonOp::NotEq,
-    }
+    **op
 }
 
-/// Converts an AST binary operation to a model binary operation.
+/// Extracts the binary operator from an AST node.
 fn resolve_binary_op(op: &ast::BinaryOpNode) -> ir::BinaryOp {
-    match &**op {
-        ast::BinaryOp::Add => ir::BinaryOp::Add,
-        ast::BinaryOp::Sub => ir::BinaryOp::Sub,
-        ast::BinaryOp::EscapedSub => ir::BinaryOp::EscapedSub,
-        ast::BinaryOp::Mul => ir::BinaryOp::Mul,
-        ast::BinaryOp::Div => ir::BinaryOp::Div,
-        ast::BinaryOp::EscapedDiv => ir::BinaryOp::EscapedDiv,
-        ast::BinaryOp::Mod => ir::BinaryOp::Mod,
-        ast::BinaryOp::Pow => ir::BinaryOp::Pow,
-        ast::BinaryOp::And => ir::BinaryOp::And,
-        ast::BinaryOp::Or => ir::BinaryOp::Or,
-        ast::BinaryOp::MinMax => ir::BinaryOp::MinMax,
-    }
+    **op
 }
 
-/// Converts an AST unary operation to a model unary operation.
+/// Extracts the unary operator from an AST node.
 fn resolve_unary_op(op: &ast::UnaryOpNode) -> ir::UnaryOp {
-    match &**op {
-        ast::UnaryOp::Neg => ir::UnaryOp::Neg,
-        ast::UnaryOp::Not => ir::UnaryOp::Not,
-    }
+    **op
 }
 
 /// Resolves a function name to a model function name.
@@ -237,13 +215,9 @@ where
     }
 }
 
-/// Converts an AST literal to a model literal.
+/// Extracts the literal value from an AST node.
 fn resolve_literal(literal: &ast::LiteralNode) -> ir::Literal {
-    match &**literal {
-        ast::Literal::Number(number) => ir::Literal::number(*number),
-        ast::Literal::String(string) => ir::Literal::string(string.clone()),
-        ast::Literal::Boolean(boolean) => ir::Literal::boolean(*boolean),
-    }
+    (**literal).clone()
 }
 
 /// Extracts internal dependencies from an expression.

--- a/src-rs/oneil_resolver/src/test/test_ir.rs
+++ b/src-rs/oneil_resolver/src/test/test_ir.rs
@@ -1,6 +1,6 @@
 use indexmap::IndexMap;
 
-use oneil_ir as ir;
+use oneil_ir::{self as ir, Literal};
 use oneil_shared::span::Span;
 
 /// Generates a span for testing purposes
@@ -19,7 +19,7 @@ pub fn reference_name(reference_name: &str) -> ir::ReferenceName {
 
 pub fn expr_literal_number(value: f64) -> ir::Expr {
     let span = unimportant_span();
-    ir::Expr::literal(span, ir::Literal::number(value))
+    ir::Expr::literal(span, Literal::Number(value))
 }
 
 pub fn empty_model() -> ir::Model {

--- a/src-rs/oneil_shared/src/expr_ops.rs
+++ b/src-rs/oneil_shared/src/expr_ops.rs
@@ -1,0 +1,65 @@
+//! Shared expression operator and literal types used by both AST and IR.
+
+/// Binary operators for mathematical and logical operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinaryOp {
+    /// Addition: `a + b`
+    Add,
+    /// Subtraction: `a - b`
+    Sub,
+    /// Escaped subtraction: `a -- b`
+    EscapedSub,
+    /// Multiplication: `a * b`
+    Mul,
+    /// Division: `a / b`
+    Div,
+    /// Escaped division: `a // b`
+    EscapedDiv,
+    /// Modulo: `a % b`
+    Mod,
+    /// Exponentiation: `a ^ b`
+    Pow,
+    /// Logical AND: `a && b`
+    And,
+    /// Logical OR: `a || b`
+    Or,
+    /// Min/max: `a | b`
+    MinMax,
+}
+
+/// Comparison operators for expressions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComparisonOp {
+    /// Less than comparison: `a < b`
+    LessThan,
+    /// Less than or equal comparison: `a <= b`
+    LessThanEq,
+    /// Greater than comparison: `a > b`
+    GreaterThan,
+    /// Greater than or equal comparison: `a >= b`
+    GreaterThanEq,
+    /// Equality comparison: `a == b`
+    Eq,
+    /// Inequality comparison: `a != b`
+    NotEq,
+}
+
+/// Unary operators for single-operand operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnaryOp {
+    /// Negation: `-a`
+    Neg,
+    /// Logical NOT: `!a`
+    Not,
+}
+
+/// Literal values that can appear in expressions.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Literal {
+    /// Numeric literal (floating-point).
+    Number(f64),
+    /// String literal.
+    String(String),
+    /// Boolean literal.
+    Boolean(bool),
+}

--- a/src-rs/oneil_shared/src/lib.rs
+++ b/src-rs/oneil_shared/src/lib.rs
@@ -2,6 +2,8 @@
 //! Shared utilities for the Oneil programming language
 
 pub mod error;
+pub mod expr_ops;
 pub mod load_result;
+pub mod naming;
 pub mod partial;
 pub mod span;

--- a/src-rs/oneil_shared/src/naming.rs
+++ b/src-rs/oneil_shared/src/naming.rs
@@ -1,0 +1,49 @@
+//! Shared naming types used by both AST and IR.
+
+/// An identifier for a variable, parameter, or other named entity in Oneil.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Identifier(String);
+
+impl Identifier {
+    /// Creates a new identifier with the given string value.
+    #[must_use]
+    pub const fn new(value: String) -> Self {
+        Self(value)
+    }
+
+    /// Returns the identifier as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for Identifier {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+/// A label in the Oneil language.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Label(String);
+
+impl Label {
+    /// Creates a new label with the given string value.
+    #[must_use]
+    pub const fn new(value: String) -> Self {
+        Self(value)
+    }
+
+    /// Returns the label as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for Label {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}


### PR DESCRIPTION
These 6 types were defined identically in both oneil_ast and oneil_ir. Now they live in oneil_shared with re-exports from both crates. The resolver's identity-mapping functions are simplified to simple derefs. Trivial constructors are also inlined into the call sites.