### PR TITLE
Add Python import tracking

### DIFF
--- a/src-rs/oneil_cli/src/lib.rs
+++ b/src-rs/oneil_cli/src/lib.rs
@@ -12,6 +12,8 @@ use anstream::{ColorChoice, eprintln, print, println};
 use clap::Parser;
 use indexmap::{IndexMap, IndexSet};
 use notify::Watcher;
+#[cfg(feature = "python")]
+use oneil_runtime::output::PythonModule;
 use oneil_runtime::{
     Runtime,
     output::{
@@ -146,19 +148,15 @@ fn apply_common_side_effects(common_args: &CommonArgs) {
 fn handle_print_python_imports(files: &[PythonPath], show_internal_errors: bool) {
     let mut runtime = Runtime::new();
 
-    let mut imports: IndexMap<PythonPath, IndexSet<String>> = IndexMap::new();
+    let mut imports: IndexMap<PythonPath, PythonModule> = IndexMap::new();
     let mut errors = Vec::new();
 
     for file in files {
         let import_result = runtime.load_python_import(file);
 
         match import_result {
-            Ok(import) => {
-                let functions: IndexSet<String> = import
-                    .into_iter()
-                    .map(|name| name.as_str().to_string())
-                    .collect();
-                imports.insert(file.clone(), functions);
+            Ok(module) => {
+                imports.insert(file.clone(), module.clone());
             }
 
             Err(runtime_errors) => {
@@ -174,20 +172,47 @@ fn handle_print_python_imports(files: &[PythonPath], show_internal_errors: bool)
     }
 
     let is_multiple_files = imports.len() > 1;
-    for (file, import) in imports {
+    for (file, module) in imports {
         if is_multiple_files {
             println!("===== {} =====", file.as_path().display());
         }
 
-        if import.is_empty() {
-            let message = format!("no functions found in `{}`", file.as_path().display());
-            let styled_message = stylesheet::NO_PYTHON_FUNCTIONS_FOUND_MESSAGE.style(message);
-            println!("{styled_message}");
-            continue;
+        let doc_string = module.get_docs();
+
+        if let Some(doc_string) = doc_string {
+            let styled_doc_string = stylesheet::PYTHON_MODULE_DOC_STRING.style(doc_string);
+            println!("{styled_doc_string}");
+            println!();
         }
 
-        for s in import {
-            println!("{s}");
+        let header = stylesheet::PYTHON_MODULE_SECTION_HEADER.style("Functions:");
+        println!("{header}");
+
+        let functions = module.get_function_names().collect::<Vec<_>>();
+
+        if functions.is_empty() {
+            let message = format!("  (no functions found in `{}`)", file.as_path().display());
+            let styled_message = stylesheet::NO_PYTHON_FUNCTIONS_FOUND_MESSAGE.style(message);
+            println!("{styled_message}");
+        } else {
+            for function in functions {
+                let styled_function =
+                    stylesheet::PYTHON_MODULE_SECTION_ITEM.style(function.as_str());
+                println!("- {styled_function}");
+            }
+        }
+
+        let imports = module.get_imports();
+        if !imports.is_empty() {
+            println!();
+
+            let header = stylesheet::PYTHON_MODULE_SECTION_HEADER.style("Imports:");
+            println!("{header}");
+
+            for import in imports {
+                let styled_import = stylesheet::PYTHON_MODULE_SECTION_ITEM.style(import.display());
+                println!("- {styled_import}");
+            }
         }
     }
 }

--- a/src-rs/oneil_cli/src/stylesheet.rs
+++ b/src-rs/oneil_cli/src/stylesheet.rs
@@ -9,7 +9,16 @@ pub const SOURCE_ANNOTATION: Style = Style::new().blue().bold();
 
 // Python output styles
 #[cfg(feature = "python")]
-pub const NO_PYTHON_FUNCTIONS_FOUND_MESSAGE: Style = Style::new().italic().dimmed();
+mod python {
+    use owo_colors::Style;
+    pub const PYTHON_MODULE_DOC_STRING: Style = Style::new().green();
+    pub const PYTHON_MODULE_SECTION_HEADER: Style = Style::new().blue().bold();
+    pub const PYTHON_MODULE_SECTION_ITEM: Style = Style::new().green();
+    pub const NO_PYTHON_FUNCTIONS_FOUND_MESSAGE: Style = Style::new().italic().dimmed();
+}
+
+#[cfg(feature = "python")]
+pub use python::*;
 
 // Model output styles
 pub const MODEL_LABEL: Style = Style::new().blue();

--- a/src-rs/oneil_lsp/src/hover.rs
+++ b/src-rs/oneil_lsp/src/hover.rs
@@ -178,6 +178,7 @@ fn format_python_import_hover(
         let functions = runtime
             .load_python_import(path)
             .ok()
+            .map(|module| module.get_function_names().collect::<Vec<_>>())
             .filter(|functions| !functions.is_empty())
             .map(|functions| {
                 let mut function_list = "**Functions:**\n".to_string();

--- a/src-rs/oneil_python/src/function.rs
+++ b/src-rs/oneil_python/src/function.rs
@@ -1,20 +1,29 @@
-use indexmap::IndexMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use indexmap::{IndexMap, IndexSet};
 use oneil_shared::symbols::PyFunctionName;
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct PythonModule {
     docs: Option<String>,
     functions: IndexMap<PyFunctionName, PythonFunction>,
+    imports: IndexSet<PathBuf>,
 }
 
 impl PythonModule {
     pub const fn new(
         docs: Option<String>,
         functions: IndexMap<PyFunctionName, PythonFunction>,
+        imports: IndexSet<PathBuf>,
     ) -> Self {
-        Self { docs, functions }
+        Self {
+            docs,
+            functions,
+            imports,
+        }
     }
 
     pub fn get_function(&self, identifier: &PyFunctionName) -> Option<&PythonFunction> {
@@ -28,17 +37,22 @@ impl PythonModule {
     pub fn get_docs(&self) -> Option<&str> {
         self.docs.as_deref()
     }
+
+    pub const fn get_imports(&self) -> &IndexSet<PathBuf> {
+        &self.imports
+    }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PythonFunction {
-    function: Py<PyAny>,
+    function: Arc<Py<PyAny>>,
     docs: Option<String>,
     line_no: Option<u32>,
 }
 
 impl PythonFunction {
-    pub const fn new(function: Py<PyAny>, docs: Option<String>, line_no: Option<u32>) -> Self {
+    pub fn new(function: Py<PyAny>, docs: Option<String>, line_no: Option<u32>) -> Self {
+        let function = Arc::new(function);
         Self {
             function,
             docs,

--- a/src-rs/oneil_python/src/load.rs
+++ b/src-rs/oneil_python/src/load.rs
@@ -1,12 +1,16 @@
 //! Loading Python code and extracting callables.
 
-use std::{ffi::CString, path::Path};
+use std::{
+    ffi::CString,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
 
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use oneil_shared::{paths::PythonPath, symbols::PyFunctionName};
 use pyo3::{
     prelude::*,
-    types::{PyDict, PyList},
+    types::{PyDict, PyList, PyTuple},
     wrap_pymodule,
 };
 
@@ -50,7 +54,9 @@ pub fn load_python_import(
         add_module_directory_to_sys_path(py, &module_directory)?;
 
         // load the code module
+        start_tracking_imports(py, &module_directory)?;
         let code_module = PyModule::from_code(py, &source_cstr, &path_cstr, &module_name_cstr)?;
+        let imports = stop_tracking_imports(py)?;
 
         // get the inspect module
         let inspect_module = PyModule::import(py, "inspect")?;
@@ -74,12 +80,14 @@ pub fn load_python_import(
 
         let module_docs = get_doc_string(&code_module, &inspect_module);
 
-        Ok::<_, PyErr>((module_docs, functions))
+        Ok::<_, PyErr>((module_docs, functions, imports))
     });
 
     // return the functions
     match functions {
-        Ok((module_docs, functions)) => Ok(PythonModule::new(module_docs, functions)),
+        Ok((module_docs, functions, imports)) => {
+            Ok(PythonModule::new(module_docs, functions, imports))
+        }
         Err(e) => Err(LoadPythonImportError::CouldNotLoadPythonModule(e)),
     }
 }
@@ -107,6 +115,29 @@ fn add_module_directory_to_sys_path(py: Python<'_>, module_directory: &Path) -> 
     Ok(())
 }
 
+fn start_tracking_imports(py: Python<'_>, module_directory: &Path) -> PyResult<()> {
+    let builtins = PyModule::import(py, "builtins")?;
+    let builtins_import_orig = builtins.getattr("__import__")?;
+
+    let import_tracker = ImportTracker::new(module_directory, builtins_import_orig.unbind())?;
+
+    builtins.setattr("__import__", import_tracker)?;
+
+    Ok(())
+}
+
+fn stop_tracking_imports(py: Python<'_>) -> PyResult<IndexSet<PathBuf>> {
+    let builtins = PyModule::import(py, "builtins")?;
+    let builtins_import_orig = builtins.getattr("__import__")?;
+
+    let import_tracker = builtins_import_orig.extract::<ImportTracker>()?;
+    let (imports, builtins_import_orig) = import_tracker.into_imports_and_original_import_fn(py);
+
+    builtins.setattr("__import__", builtins_import_orig)?;
+
+    Ok(imports)
+}
+
 fn get_doc_string(
     value: &Bound<'_, PyAny>,
     inspect_module: &Bound<'_, PyModule>,
@@ -131,4 +162,88 @@ fn get_line_no(value: &Bound<'_, PyAny>, inspect_module: &Bound<'_, PyModule>) -
         .expect("`getsourcelines` should return a tuple of a string and a u32");
 
     Some(line_no)
+}
+
+/// Tracks imports made by a Python module.
+///
+/// Note that only imports from the module directory are tracked. This ensures
+/// that imports from builtin libraries and other libraries like `numpy` are not
+/// tracked.
+#[pyclass(from_py_object)]
+#[derive(Debug)]
+struct ImportTracker {
+    pub module_directory: PathBuf,
+    pub imports: Arc<Mutex<IndexSet<PathBuf>>>,
+    pub builtins_import_orig: Py<PyAny>,
+}
+
+impl ImportTracker {
+    pub fn new(module_directory: &Path, builtins_import_orig: Py<PyAny>) -> PyResult<Self> {
+        Ok(Self {
+            module_directory: module_directory.to_path_buf(),
+            imports: Arc::new(Mutex::new(IndexSet::new())),
+            builtins_import_orig,
+        })
+    }
+
+    pub fn into_imports_and_original_import_fn(
+        self,
+        py: Python<'_>,
+    ) -> (IndexSet<PathBuf>, Py<PyAny>) {
+        (
+            self.imports
+                .lock()
+                .expect("imports should not be poisoned")
+                .clone(),
+            self.builtins_import_orig.clone_ref(py),
+        )
+    }
+}
+
+#[expect(
+    clippy::multiple_inherent_impl,
+    reason = "this block is for Python, not Rust"
+)]
+#[pymethods]
+impl ImportTracker {
+    #[pyo3(signature = (*args, **kwargs))]
+    fn __call__<'py>(
+        &self,
+        py: Python<'py>,
+        args: &Bound<'py, PyTuple>,
+        kwargs: Option<&Bound<'py, PyDict>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let result = self.builtins_import_orig.bind(py).call(args, kwargs)?;
+
+        let result_module = result.cast::<PyModule>()?;
+
+        // try to get the file path of the imported module
+        //
+        // built-in modules do not have a __file__ attribute, so we skip them
+        if let Ok(file_path) = result_module.getattr("__file__") {
+            let file_path = file_path.extract::<String>()?;
+            let file_path = PathBuf::from(file_path);
+
+            // if the file path starts with the module directory, add it to the
+            // import list
+            if file_path.starts_with(&self.module_directory) {
+                self.imports
+                    .lock()
+                    .expect("imports should not be poisoned")
+                    .insert(file_path);
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+impl Clone for ImportTracker {
+    fn clone(&self) -> Self {
+        Python::attach(|py| Self {
+            module_directory: self.module_directory.clone(),
+            imports: Arc::clone(&self.imports),
+            builtins_import_orig: self.builtins_import_orig.clone_ref(py),
+        })
+    }
 }

--- a/src-rs/oneil_python/src/load.rs
+++ b/src-rs/oneil_python/src/load.rs
@@ -1,10 +1,14 @@
 //! Loading Python code and extracting callables.
 
-use std::ffi::CString;
+use std::{ffi::CString, path::Path};
 
 use indexmap::IndexMap;
 use oneil_shared::{paths::PythonPath, symbols::PyFunctionName};
-use pyo3::{prelude::*, types::PyDict, wrap_pymodule};
+use pyo3::{
+    prelude::*,
+    types::{PyDict, PyList},
+    wrap_pymodule,
+};
 
 use crate::{
     error::LoadPythonImportError,
@@ -16,12 +20,22 @@ pub fn load_python_import(
     path: &PythonPath,
     source: &str,
 ) -> Result<PythonModule, LoadPythonImportError> {
+    // get the module directory from the path
+    let module_directory = path
+        .as_path()
+        .parent()
+        // if the parent is an empty string, use the current directory
+        .map(|p| if p == "" { Path::new(".") } else { p })
+        .unwrap_or_else(|| Path::new("."))
+        .canonicalize()
+        .expect("path should be directory that exists");
+
     // get the module name from the path
-    let path = path.as_path().to_string_lossy();
-    let module_name = path.trim_end_matches(".py").replace('/', ".");
+    let path_str = path.as_path().to_string_lossy();
+    let module_name = path_str.trim_end_matches(".py").replace('/', ".");
 
     // convert the path and module name to C strings
-    let path_cstr = CString::new(path.as_bytes()).expect("path should not have a null byte");
+    let path_cstr = CString::new(path_str.as_bytes()).expect("path should not have a null byte");
     let module_name_cstr =
         CString::new(module_name).expect("module name should not have a null byte");
 
@@ -33,6 +47,7 @@ pub fn load_python_import(
 
     let functions = Python::attach(|py| {
         insert_oneil_module_into_python(py)?;
+        add_module_directory_to_sys_path(py, &module_directory)?;
 
         // load the code module
         let code_module = PyModule::from_code(py, &source_cstr, &path_cstr, &module_name_cstr)?;
@@ -80,6 +95,15 @@ fn insert_oneil_module_into_python(py: Python<'_>) -> PyResult<()> {
     // Insert oneil_python_module into sys.modules
     py_modules.set_item("oneil", oneil_module)?;
 
+    Ok(())
+}
+
+// this adds the module directory to the sys.path so that the module can import
+// other modules in the module directory
+fn add_module_directory_to_sys_path(py: Python<'_>, module_directory: &Path) -> PyResult<()> {
+    let sys = PyModule::import(py, "sys")?;
+    let path = sys.getattr("path")?.cast_into::<PyList>()?;
+    path.insert(0, module_directory.as_os_str())?;
     Ok(())
 }
 

--- a/src-rs/oneil_runtime/src/output/mod.rs
+++ b/src-rs/oneil_runtime/src/output/mod.rs
@@ -10,6 +10,7 @@ pub use oneil_output::{
     BuiltinDependency, DebugInfo, DependencySet, ExternalDependency, Model, ModelEvalErrors,
     Number, Parameter, ParameterDependency, PrintLevel, Test, TestResult, Unit, Value,
 };
+pub use oneil_python::function::PythonModule;
 pub use oneil_shared::{error::OneilDiagnostic, span::Span};
 
 pub mod tree {

--- a/src-rs/oneil_runtime/src/runtime/python.rs
+++ b/src-rs/oneil_runtime/src/runtime/python.rs
@@ -1,6 +1,5 @@
 //! Python import and evaluation for the runtime (when the `python` feature is enabled).
 
-use indexmap::IndexSet;
 use oneil_output::EvalError;
 use oneil_python::{PythonEvalError, PythonFunction, function::PythonModule};
 
@@ -46,14 +45,13 @@ impl Runtime {
     pub fn load_python_import(
         &mut self,
         path: &PythonPath,
-    ) -> Result<IndexSet<&PyFunctionName>, RuntimeErrors> {
+    ) -> Result<&PythonModule, RuntimeErrors> {
         self.load_python_import_internal(path);
 
         let names_opt = self
             .python_import_cache
             .get_entry(path)
-            .and_then(|result| result.as_ref().ok())
-            .map(|functions| functions.get_function_names().collect());
+            .and_then(|result| result.as_ref().ok());
 
         let errors = self.get_python_import_errors(path);
 

--- a/src-rs/oneil_snapshot_tests/fixtures/python/py_helpers.py
+++ b/src-rs/oneil_snapshot_tests/fixtures/python/py_helpers.py
@@ -1,0 +1,6 @@
+"""Helpers for snapshot tests that exercise Python imports."""
+
+
+def square_area(side):
+    """Return the area of a square with side length `side`."""
+    return side * side

--- a/src-rs/oneil_snapshot_tests/fixtures/python/python_square_area.on
+++ b/src-rs/oneil_snapshot_tests/fixtures/python/python_square_area.on
@@ -1,0 +1,8 @@
+# Model that calls a Python function from an imported module.
+import py_helpers
+
+Side: s = 3 :m
+Area: A = square_area(s) :m^2
+Floor area: min_area = 8 :m^2
+
+test: A > min_area

--- a/src-rs/oneil_snapshot_tests/src/snapshots/oneil_snapshot_tests__test__python_square_area.snap
+++ b/src-rs/oneil_snapshot_tests/src/snapshots/oneil_snapshot_tests__test__python_square_area.snap
@@ -1,0 +1,11 @@
+---
+source: src-rs/oneil_snapshot_tests/src/test.rs
+expression: "run_fixture(\"python/python_square_area.on\")"
+---
+Model: fixtures/python/python_square_area.on
+Tests: 1/1
+  test 1: PASS
+Parameters:
+  s = MeasuredNumber(MeasuredNumber { normalized_value: NormalizedNumber(Scalar(3.0)), unit: Unit { dimension_map: DimensionMap({Distance: 1.0}), magnitude: 1.0, is_db: false, display_unit: Unit { name: "m", exponent: 1.0 } } })
+  A = MeasuredNumber(MeasuredNumber { normalized_value: NormalizedNumber(Scalar(9.0)), unit: Unit { dimension_map: DimensionMap({Distance: 2.0}), magnitude: 1.0, is_db: false, display_unit: Unit { name: "m", exponent: 2.0 } } })
+  min_area = MeasuredNumber(MeasuredNumber { normalized_value: NormalizedNumber(Scalar(8.0)), unit: Unit { dimension_map: DimensionMap({Distance: 2.0}), magnitude: 1.0, is_db: false, display_unit: Unit { name: "m", exponent: 2.0 } } })

--- a/src-rs/oneil_snapshot_tests/src/test.rs
+++ b/src-rs/oneil_snapshot_tests/src/test.rs
@@ -349,3 +349,13 @@ fn chain_apply_validation_cycle() {
     // a generic contribution diagnostic at `mid.on`'s `apply` span.
     insta::assert_snapshot!(run_fixture("chain_apply_validation_cycle/parent.on"));
 }
+
+// =============================================================================
+// Python integration
+// =============================================================================
+
+/// Snapshot for evaluating a model that imports a sibling `.py` module and calls a function.
+#[test]
+fn python_square_area() {
+    insta::assert_snapshot!(run_fixture("python/python_square_area.on"));
+}


### PR DESCRIPTION
_NOTE: This PR is dependent on [Fallback support](https://github.com/careweather/oneil/pull/36) and should not be reviewed until that PR is merged_

This PR adds tracking for Python imports within a script by replacing the standard import mechanism (`builtins.__import__`) with a custom mechanism that tracks local imports.