### PR TITLE
Add caching for python function calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+__oncache__/
 __pycache__/
 .vscode/
 .venv/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,6 +815,7 @@ dependencies = [
  "oneil_ir",
  "oneil_output",
  "oneil_parser",
+ "oneil_py_call_cache",
  "oneil_python",
  "oneil_shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,6 +800,7 @@ dependencies = [
  "oneil_shared",
  "pyo3",
  "serde",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -1581,6 +1582,12 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "zmij"

--- a/docs/guide/src/11-importing-python.md
+++ b/docs/guide/src/11-importing-python.md
@@ -69,5 +69,3 @@ Python function results are automatically cached to avoid re-running expensive c
   untouched unless a simulation's latest cached inputs or output changed
 - **Auto-invalidates** when imported Python source files, their local Python
   dependencies, or the simulation inputs change
-
-Use the `cache` command in the CLI to view cache statistics or `cache clear` to clear it.

--- a/docs/guide/src/11-importing-python.md
+++ b/docs/guide/src/11-importing-python.md
@@ -50,10 +50,6 @@ This is particularly useful for:
 
 ## Function Caching
 
-> [!NOTE]
-> This is not currently implemented in the Rust implementation but will be
-> implemented soon.
-
 Python function results are automatically cached to avoid re-running expensive calculations. The cache:
 
 - **Persists across REPL sessions** - Close and reopen Oneil, cached results
@@ -69,3 +65,5 @@ Python function results are automatically cached to avoid re-running expensive c
   untouched unless a simulation's latest cached inputs or output changed
 - **Auto-invalidates** when imported Python source files, their local Python
   dependencies, or the simulation inputs change
+
+For each import, the cache takes into account the imported python file, its local Python dependencies, and the `requirements.txt` file in the same directory (if any exists).

--- a/src-rs/oneil_cli/src/lib.rs
+++ b/src-rs/oneil_cli/src/lib.rs
@@ -177,14 +177,21 @@ fn handle_print_python_imports(files: &[PythonPath], show_internal_errors: bool)
             println!("===== {} =====", file.as_path().display());
         }
 
-        let doc_string = module.get_docs();
+        // print the hash
+        let header = stylesheet::PYTHON_MODULE_SECTION_HEADER.style("Hash:");
+        let hash = module.get_hash();
+        let styled_hash = stylesheet::PYTHON_MODULE_SECTION_ITEM.style(format!("{hash:016x}"));
+        println!("{header} {styled_hash}");
+        println!();
 
-        if let Some(doc_string) = doc_string {
+        // print the doc string if it exists
+        if let Some(doc_string) = module.get_docs() {
             let styled_doc_string = stylesheet::PYTHON_MODULE_DOC_STRING.style(doc_string);
             println!("{styled_doc_string}");
             println!();
         }
 
+        // print the functions
         let header = stylesheet::PYTHON_MODULE_SECTION_HEADER.style("Functions:");
         println!("{header}");
 
@@ -202,6 +209,7 @@ fn handle_print_python_imports(files: &[PythonPath], show_internal_errors: bool)
             }
         }
 
+        // print the imports
         let imports = module.get_imports();
         if !imports.is_empty() {
             println!();

--- a/src-rs/oneil_eval/src/context.rs
+++ b/src-rs/oneil_eval/src/context.rs
@@ -49,11 +49,12 @@ pub trait ExternalEvaluationContext {
     /// Returns an error if there was an error evaluating the imported function.
     #[cfg(feature = "python")]
     fn evaluate_imported_function(
-        &self,
+        &mut self,
         python_path: &PythonPath,
         identifier: &PyFunctionName,
         function_call_span: Span,
         args: Vec<(output::Value, Span)>,
+        callsite_info: &CallsiteInfo,
     ) -> Option<Result<output::Value, Box<EvalError>>>;
 
     /// Returns a unit by name if it is defined in the builtin context.
@@ -225,6 +226,20 @@ enum SlotPeek {
     TakenForEval(Box<ir::Parameter>),
 }
 
+/// Information about the callsite of the function being evaluated.
+///
+/// This is used for caching Python function calls.
+#[derive(Debug, Default, Clone)]
+pub enum CallsiteInfo {
+    /// A parameter in a model.
+    Parameter(EvalInstanceKey, ParameterName),
+    /// A test in a model.
+    Test(EvalInstanceKey, TestIndex),
+    /// Other callsite (e.g. an expression in the REPL).
+    #[default]
+    Other,
+}
+
 /// Evaluation context that tracks per-instance memo state for lazy parameter evaluation.
 ///
 /// The context owns the parameter memo table for every instance the evaluator may touch:
@@ -245,6 +260,9 @@ pub struct EvalContext<'external, E: ExternalEvaluationContext> {
     eval_scope: Vec<EvalInstanceKey>,
     external_context: &'external mut E,
 
+    /// Context for the callsite of any function evaluated in the context.
+    callsite_context: Vec<CallsiteInfo>,
+
     /// Warnings for the parameter or test expression currently being evaluated.
     expression_eval_warnings: Vec<output::EvalWarning>,
 }
@@ -264,6 +282,7 @@ impl<'external, E: ExternalEvaluationContext> EvalContext<'external, E> {
             eval_scope: Vec::new(),
             external_context,
             expression_eval_warnings: Vec::new(),
+            callsite_context: Vec::new(),
         }
     }
 
@@ -292,6 +311,7 @@ impl<'external, E: ExternalEvaluationContext> EvalContext<'external, E> {
             models,
             eval_scope: Vec::new(),
             external_context,
+            callsite_context: Vec::new(),
             expression_eval_warnings: Vec::new(),
         }
     }
@@ -366,6 +386,7 @@ impl<'external, E: ExternalEvaluationContext> EvalContext<'external, E> {
             models,
             eval_scope: Vec::new(),
             external_context,
+            callsite_context: Vec::new(),
             expression_eval_warnings: Vec::new(),
         }
     }
@@ -617,7 +638,11 @@ impl<'external, E: ExternalEvaluationContext> EvalContext<'external, E> {
                     self.push_active_model(ak.clone());
                 }
 
-                let eval_result = eval_parameter::eval_parameter(&param, self);
+                let eval_result =
+                    eval_parameter::eval_parameter(parameter_name.clone(), &param, self);
+
+                // pop the callsite context the parameter evaluation
+                let _callsite_info = self.pop_callsite_context();
 
                 if let Some(ref ak) = anchor_key {
                     self.pop_active_model(ak);
@@ -698,7 +723,7 @@ impl<'external, E: ExternalEvaluationContext> EvalContext<'external, E> {
 
     /// Evaluates an imported function with the given arguments.
     pub fn evaluate_imported_function(
-        &self,
+        &mut self,
         python_path: &PythonPath,
         name: &PyFunctionName,
         function_call_span: Span,
@@ -706,8 +731,15 @@ impl<'external, E: ExternalEvaluationContext> EvalContext<'external, E> {
     ) -> Result<output::Value, Box<EvalError>> {
         #[cfg(feature = "python")]
         {
+            let callsite_info = self.callsite_context.last().cloned().unwrap_or_default();
             self.external_context
-                .evaluate_imported_function(python_path, name, function_call_span, args)
+                .evaluate_imported_function(
+                    python_path,
+                    name,
+                    function_call_span,
+                    args,
+                    &callsite_info,
+                )
                 .expect("imported function should be defined (checked during resolution)")
         }
 
@@ -735,8 +767,31 @@ impl<'external, E: ExternalEvaluationContext> EvalContext<'external, E> {
     /// Clears warnings for a new parameter or test expression evaluation.
     ///
     /// Call at the start of evaluating each top-level parameter or test expression.
-    pub fn begin_expression_evaluation(&mut self) {
+    pub fn begin_parameter_evaluation(&mut self, parameter_name: ParameterName) {
         self.expression_eval_warnings.clear();
+
+        let current_key = self
+            .eval_scope
+            .last()
+            .expect("current model should be set when beginning a parameter evaluation");
+
+        self.callsite_context
+            .push(CallsiteInfo::Parameter(current_key.clone(), parameter_name));
+    }
+
+    /// Clears warnings for a new test expression evaluation.
+    ///
+    /// Call at the start of evaluating each top-level test expression.
+    pub fn begin_test_evaluation(&mut self, test_index: TestIndex) {
+        self.expression_eval_warnings.clear();
+
+        let current_key = self
+            .eval_scope
+            .last()
+            .expect("current model should be set when beginning a test evaluation");
+
+        self.callsite_context
+            .push(CallsiteInfo::Test(current_key.clone(), test_index));
     }
 
     /// Takes warnings collected while evaluating the current expression.
@@ -831,6 +886,7 @@ impl<'external, E: ExternalEvaluationContext> EvalContext<'external, E> {
             panic!("current model should be set when adding a parameter result");
         };
 
+        // add the parameter result to the current model
         let model = self
             .models
             .get_mut(current_key)
@@ -886,11 +942,37 @@ impl<'external, E: ExternalEvaluationContext> EvalContext<'external, E> {
         test_index: TestIndex,
         test_result: Result<output::Test, Vec<EvalError>>,
     ) {
+        let current_model = self
+            .eval_scope
+            .last()
+            .expect("current model should be set when adding a test result");
+
+        // assert that the callsite context is the expected test index
+        let Some(CallsiteInfo::Test(expected_model_path, expected_test_index)) =
+            self.callsite_context.pop()
+        else {
+            panic!("callsite context should be a test when adding a test result");
+        };
+        assert_eq!(&expected_model_path, current_model);
+        assert_eq!(expected_test_index, test_index);
+
+        // add the test result to the current model
         let model = self
             .models
             .get_mut(key)
             .expect("model should be registered when adding a test result");
 
         model.tests.insert(test_index, test_result);
+    }
+
+    /// Pops the last callsite context.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the callsite context is empty.
+    fn pop_callsite_context(&mut self) -> CallsiteInfo {
+        self.callsite_context
+            .pop()
+            .expect("callsite context should not be empty")
     }
 }

--- a/src-rs/oneil_eval/src/eval_expr.rs
+++ b/src-rs/oneil_eval/src/eval_expr.rs
@@ -427,7 +427,7 @@ fn eval_function_call<E: ExternalEvaluationContext>(
     name: &ir::FunctionName,
     function_call_span: Span,
     args: Vec<(Value, Span)>,
-    context: &EvalContext<'_, E>,
+    context: &mut EvalContext<'_, E>,
 ) -> Result<Value, Vec<EvalError>> {
     match name {
         ir::FunctionName::Builtin(fn_identifier, fn_identifier_span) => {

--- a/src-rs/oneil_eval/src/eval_model.rs
+++ b/src-rs/oneil_eval/src/eval_model.rs
@@ -1,7 +1,7 @@
 use indexmap::IndexMap;
 use oneil_frontend::{InstanceGraph, InstancedModel};
 use oneil_ir as ir;
-use oneil_shared::{EvalInstanceKey, partial::MaybePartialResult};
+use oneil_shared::{EvalInstanceKey, partial::MaybePartialResult, symbols::TestIndex};
 
 use oneil_output::{self as output, EvalError, ExpectedType, Model, ModelEvalErrors, Value};
 
@@ -77,7 +77,7 @@ fn force_all_models<E: ExternalEvaluationContext>(
         }
         context.push_active_model(key.clone());
         for (test_index, test) in tests {
-            let test_result = eval_test(&test, context);
+            let test_result = eval_test(test_index, &test, context);
             context.add_test_result(&key, test_index, test_result);
         }
         context.pop_active_model(&key);
@@ -96,10 +96,12 @@ fn propagate_reference_errors<E: ExternalEvaluationContext>(context: &mut EvalCo
 
 /// Evaluates a single test in the context of the currently active scope.
 fn eval_test<E: ExternalEvaluationContext>(
+    test_index: TestIndex,
     test: &ir::Test,
     context: &mut EvalContext<'_, E>,
 ) -> Result<output::Test, Vec<EvalError>> {
-    context.begin_expression_evaluation();
+    context.begin_test_evaluation(test_index);
+
     let (test_result, expr_span) = eval_expr::eval_expr(test.expr(), context)?;
     let warnings = context.take_expression_warnings();
 

--- a/src-rs/oneil_eval/src/eval_parameter.rs
+++ b/src-rs/oneil_eval/src/eval_parameter.rs
@@ -32,28 +32,27 @@ pub struct EvalParameterResult {
 /// - The parameter value is outside the limits.
 /// - The parameter unit does not match the limit.
 pub fn eval_parameter<E: ExternalEvaluationContext>(
+    parameter_name: ParameterName,
     parameter: &ir::Parameter,
     context: &mut EvalContext<'_, E>,
 ) -> Result<EvalParameterResult, Vec<EvalError>> {
-    // TODO: this is about where we would use `trace_level`, but I'm not yet sure
-    //       how to handle it.
-
     // Overlay RHSes have already been applied to `parameter.value()` by
     // the design composition step, and any anchor-scope handling is
     // expressed through [`ir::DesignProvenance::anchor_path`] which the
     // caller has already pushed onto `context`'s scope stack. Eval
     // therefore just runs the parameter's value as-is — no overlay
     // lookup needed here.
-    eval_parameter_from_resolved_value(parameter.value(), parameter, context)
+    eval_parameter_from_resolved_value(parameter_name, parameter.value(), parameter, context)
 }
 
 /// Evaluates a parameter using an explicit resolved [`ir::ParameterValue`] (IR default or overlay).
 pub fn eval_parameter_from_resolved_value<E: ExternalEvaluationContext>(
+    parameter_name: ParameterName,
     value_source: &ir::ParameterValue,
     parameter: &ir::Parameter,
     context: &mut EvalContext<'_, E>,
 ) -> Result<EvalParameterResult, Vec<EvalError>> {
-    context.begin_expression_evaluation();
+    context.begin_parameter_evaluation(parameter_name);
 
     // evaluate the value and the unit
     let (value, expr_span, unit_ir) = match value_source {
@@ -954,8 +953,8 @@ mod tests {
         let mut context = EvalContext::new(&mut external);
         context.push_active_model(EvalInstanceKey::root(test_model_path("test")));
 
-        let parameter_value =
-            eval_parameter(&parameter, &mut context).expect("eval should succeed");
+        let parameter_value = eval_parameter(parameter.name().clone(), &parameter, &mut context)
+            .expect("eval should succeed");
 
         // check the parameter value
         let Value::Number(number) = parameter_value.value else {
@@ -982,8 +981,8 @@ mod tests {
         let mut context = EvalContext::new(&mut external);
         context.push_active_model(EvalInstanceKey::root(test_model_path("test")));
 
-        let parameter_value =
-            eval_parameter(&parameter, &mut context).expect("eval should succeed");
+        let parameter_value = eval_parameter(parameter.name().clone(), &parameter, &mut context)
+            .expect("eval should succeed");
 
         let expected_dimensions = [(Dimension::Distance, 1.0)];
 
@@ -1020,8 +1019,8 @@ mod tests {
         let mut context = EvalContext::new(&mut external);
         context.push_active_model(EvalInstanceKey::root(test_model_path("test")));
 
-        let parameter_value =
-            eval_parameter(&parameter, &mut context).expect("eval should succeed");
+        let parameter_value = eval_parameter(parameter.name().clone(), &parameter, &mut context)
+            .expect("eval should succeed");
 
         let expected_dimensions = [(Dimension::Distance, 1.0)];
 
@@ -1061,8 +1060,8 @@ mod tests {
         let mut context = EvalContext::new(&mut external);
         context.push_active_model(EvalInstanceKey::root(test_model_path("test")));
 
-        let parameter_value =
-            eval_parameter(&parameter, &mut context).expect("eval should succeed");
+        let parameter_value = eval_parameter(parameter.name().clone(), &parameter, &mut context)
+            .expect("eval should succeed");
 
         let expected_dimensions = [(Dimension::Distance, 1.0), (Dimension::Time, -1.0)];
 
@@ -1100,8 +1099,8 @@ mod tests {
         let mut context = EvalContext::new(&mut external);
         context.push_active_model(EvalInstanceKey::root(test_model_path("test")));
 
-        let parameter_value =
-            eval_parameter(&parameter, &mut context).expect("eval should succeed");
+        let parameter_value = eval_parameter(parameter.name().clone(), &parameter, &mut context)
+            .expect("eval should succeed");
 
         let expected_dimensions = [];
 
@@ -1139,8 +1138,8 @@ mod tests {
         let mut context = EvalContext::new(&mut external);
         context.push_active_model(EvalInstanceKey::root(test_model_path("test")));
 
-        let parameter_value =
-            eval_parameter(&parameter, &mut context).expect("eval should succeed");
+        let parameter_value = eval_parameter(parameter.name().clone(), &parameter, &mut context)
+            .expect("eval should succeed");
 
         let expected_dimensions = [
             (Dimension::Mass, 1.0),
@@ -1199,8 +1198,8 @@ mod tests {
             [helper::UnitSpec::new(Some("m"), Some("k"), false, 1.0)],
         );
 
-        let parameter_value =
-            eval_parameter(&parameter, &mut context).expect("eval should succeed");
+        let parameter_value = eval_parameter(parameter.name().clone(), &parameter, &mut context)
+            .expect("eval should succeed");
 
         let expected_dimensions = [(Dimension::Distance, 1.0)];
 
@@ -1260,8 +1259,8 @@ mod tests {
             [helper::UnitSpec::new(Some("N"), None, false, 1.0)],
         );
 
-        let parameter_value =
-            eval_parameter(&parameter, &mut context).expect("eval should succeed");
+        let parameter_value = eval_parameter(parameter.name().clone(), &parameter, &mut context)
+            .expect("eval should succeed");
 
         let expected_dimensions = [
             (Dimension::Mass, 1.0),
@@ -1321,8 +1320,8 @@ mod tests {
             [helper::UnitSpec::new(Some("W"), None, false, 1.0)],
         );
 
-        let parameter_value =
-            eval_parameter(&parameter, &mut context).expect("eval should succeed");
+        let parameter_value = eval_parameter(parameter.name().clone(), &parameter, &mut context)
+            .expect("eval should succeed");
 
         let expected_dimensions = [
             (Dimension::Mass, 1.0),
@@ -1376,8 +1375,8 @@ mod tests {
             [helper::UnitSpec::new(Some("W"), None, false, 2.0)],
         );
 
-        let parameter_value =
-            eval_parameter(&parameter, &mut context).expect("eval should succeed");
+        let parameter_value = eval_parameter(parameter.name().clone(), &parameter, &mut context)
+            .expect("eval should succeed");
 
         let expected_dimensions = [
             (Dimension::Mass, 2.0),
@@ -1436,8 +1435,8 @@ mod tests {
             [helper::UnitSpec::new(Some("m"), None, false, 2.0)],
         );
 
-        let parameter_value =
-            eval_parameter(&parameter, &mut context).expect("eval should succeed");
+        let parameter_value = eval_parameter(parameter.name().clone(), &parameter, &mut context)
+            .expect("eval should succeed");
 
         let expected_dimensions = [(Dimension::Distance, 2.0)];
 
@@ -1492,8 +1491,8 @@ mod tests {
             [helper::UnitSpec::new(Some("m"), None, false, 1.0)],
         );
 
-        let parameter_value =
-            eval_parameter(&parameter, &mut context).expect("eval should succeed");
+        let parameter_value = eval_parameter(parameter.name().clone(), &parameter, &mut context)
+            .expect("eval should succeed");
 
         let expected_dimensions = [(Dimension::Distance, 1.0)];
 
@@ -1552,8 +1551,8 @@ mod tests {
             ],
         );
 
-        let parameter_value =
-            eval_parameter(&parameter, &mut context).expect("eval should succeed");
+        let parameter_value = eval_parameter(parameter.name().clone(), &parameter, &mut context)
+            .expect("eval should succeed");
 
         let expected_dimensions = [];
 
@@ -1610,8 +1609,8 @@ mod tests {
             [helper::UnitSpec::new(Some("m"), None, false, 1.0)],
         );
 
-        let parameter_value =
-            eval_parameter(&parameter, &mut context).expect("eval should succeed");
+        let parameter_value = eval_parameter(parameter.name().clone(), &parameter, &mut context)
+            .expect("eval should succeed");
 
         let expected_dimensions = [(Dimension::Distance, 1.0)];
 
@@ -1667,8 +1666,8 @@ mod tests {
             [helper::UnitSpec::new(Some("m"), None, false, 1.0)],
         );
 
-        let parameter_value =
-            eval_parameter(&parameter, &mut context).expect("eval should succeed");
+        let parameter_value = eval_parameter(parameter.name().clone(), &parameter, &mut context)
+            .expect("eval should succeed");
 
         let expected_dimensions = [(Dimension::Distance, 1.0)];
 
@@ -2236,8 +2235,8 @@ mod tests {
             for (name, value, units) in previous_parameters {
                 let parameter = build_simple_parameter(name, value, units);
 
-                let parameter_value =
-                    eval_parameter(&parameter, context).expect("eval should succeed");
+                let parameter_value = eval_parameter(parameter.name().clone(), &parameter, context)
+                    .expect("eval should succeed");
                 let parameter_result = build_parameter_result(name, parameter_value.value);
                 context.add_parameter_result(ParameterName::from(name), Ok(parameter_result));
             }

--- a/src-rs/oneil_eval/src/lib.rs
+++ b/src-rs/oneil_eval/src/lib.rs
@@ -7,7 +7,7 @@ mod eval_model;
 mod eval_parameter;
 mod eval_unit;
 
-pub use context::{ExternalEvaluationContext, IrLoadError};
+pub use context::{CallsiteInfo, ExternalEvaluationContext, IrLoadError};
 pub use eval_expr::eval_expr_in_model;
 pub use eval_model::eval_model_from_graph;
 

--- a/src-rs/oneil_eval/src/test_context.rs
+++ b/src-rs/oneil_eval/src/test_context.rs
@@ -15,6 +15,8 @@ use oneil_shared::{
     symbols::{BuiltinFunctionName, BuiltinValueName, UnitBaseName, UnitPrefix},
 };
 
+#[cfg(feature = "python")]
+use crate::context::CallsiteInfo;
 use crate::context::ExternalEvaluationContext;
 
 /// Returns a [`ModelPath`] for use in tests (path without extension, e.g. `"test"` → `test.on`).
@@ -66,11 +68,12 @@ impl ExternalEvaluationContext for TestExternalContext {
 
     #[cfg(feature = "python")]
     fn evaluate_imported_function(
-        &self,
+        &mut self,
         _python_path: &oneil_shared::paths::PythonPath,
         _identifier: &oneil_shared::symbols::PyFunctionName,
         _function_call_span: Span,
         _args: Vec<(Value, Span)>,
+        _callsite_info: &CallsiteInfo,
     ) -> Option<Result<Value, Box<EvalError>>> {
         // For now, we don't support imported functions in tests
         None

--- a/src-rs/oneil_py_call_cache/src/file.rs
+++ b/src-rs/oneil_py_call_cache/src/file.rs
@@ -45,6 +45,12 @@ impl FileCache {
     ///
     /// Returns [`WriteCacheError`] if the file cannot be created or JSON serialization fails.
     pub fn write_to_path(&self, path: impl AsRef<Path>) -> Result<(), WriteCacheError> {
+        if let Some(dir) = path.as_ref().parent()
+            && !dir.exists()
+        {
+            std::fs::create_dir_all(dir).map_err(WriteCacheError::Io)?;
+        }
+
         let file = File::create(path.as_ref()).map_err(WriteCacheError::Io)?;
         serde_json::to_writer_pretty(file, self).map_err(WriteCacheError::Serde)?;
         Ok(())

--- a/src-rs/oneil_python/Cargo.toml
+++ b/src-rs/oneil_python/Cargo.toml
@@ -18,6 +18,7 @@ oneil_output = { path = "../oneil_output" }
 oneil_shared = { path = "../oneil_shared" }
 pyo3 = { workspace = true }
 serde = { workspace = true }
+xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 
 [features]
 default = ["python-lib", "rust-lib"]

--- a/src-rs/oneil_python/src/error.rs
+++ b/src-rs/oneil_python/src/error.rs
@@ -1,5 +1,9 @@
 //! Error types for Python integration.
 
+use std::io;
+use std::path::PathBuf;
+
+use indexmap::IndexMap;
 use oneil_shared::error::{AsOneilDiagnostic, Context, DiagnosticKind};
 use pyo3::Python;
 use pyo3::types::PyTracebackMethods;
@@ -12,6 +16,11 @@ pub enum LoadPythonImportError {
     SourceHasNullByte,
     /// Python raised an error while loading the module.
     CouldNotLoadPythonModule(pyo3::PyErr),
+    /// Could not calculate the source hash.
+    CouldNotCalculateSourceHash {
+        /// File errors.
+        file_errors: Box<IndexMap<PathBuf, io::Error>>,
+    },
 }
 
 impl AsOneilDiagnostic for LoadPythonImportError {
@@ -22,7 +31,10 @@ impl AsOneilDiagnostic for LoadPythonImportError {
     fn message(&self) -> String {
         match self {
             Self::SourceHasNullByte => "Python source contains a null byte".to_string(),
-            Self::CouldNotLoadPythonModule(_error) => "Could not load Python module".to_string(),
+            Self::CouldNotLoadPythonModule(_error) => "could not load Python module".to_string(),
+            Self::CouldNotCalculateSourceHash { file_errors: _ } => {
+                "Could not calculate source hash".to_string()
+            }
         }
     }
 
@@ -37,6 +49,12 @@ impl AsOneilDiagnostic for LoadPythonImportError {
                     |traceback| vec![Context::Note(error.to_string()), Context::Note(traceback)],
                 )
             }),
+            Self::CouldNotCalculateSourceHash { file_errors } => file_errors
+                .iter()
+                .map(|(path, error)| {
+                    Context::Note(format!("could not read {}: {}", path.display(), error))
+                })
+                .collect(),
         }
     }
 }

--- a/src-rs/oneil_python/src/function.rs
+++ b/src-rs/oneil_python/src/function.rs
@@ -11,6 +11,7 @@ pub struct PythonModule {
     docs: Option<String>,
     functions: IndexMap<PyFunctionName, PythonFunction>,
     imports: IndexSet<PathBuf>,
+    hash: u64,
 }
 
 impl PythonModule {
@@ -18,11 +19,13 @@ impl PythonModule {
         docs: Option<String>,
         functions: IndexMap<PyFunctionName, PythonFunction>,
         imports: IndexSet<PathBuf>,
+        hash: u64,
     ) -> Self {
         Self {
             docs,
             functions,
             imports,
+            hash,
         }
     }
 
@@ -40,6 +43,10 @@ impl PythonModule {
 
     pub const fn get_imports(&self) -> &IndexSet<PathBuf> {
         &self.imports
+    }
+
+    pub const fn get_hash(&self) -> u64 {
+        self.hash
     }
 }
 

--- a/src-rs/oneil_python/src/lib.rs
+++ b/src-rs/oneil_python/src/lib.rs
@@ -15,6 +15,7 @@ pub mod eval;
 pub mod function;
 pub mod load;
 mod py_compat;
+mod source_hash;
 
 #[cfg(feature = "rust-lib")]
 pub use rust_lib::*;

--- a/src-rs/oneil_python/src/load.rs
+++ b/src-rs/oneil_python/src/load.rs
@@ -87,12 +87,18 @@ pub fn load_python_import(
 
     // return the functions
     match functions {
-        Ok((module_docs, functions, imports)) => {
+        Ok((module_docs, functions, mut imports)) => {
+            // add the `requirements.txt` path to the imports if it exists
+            let maybe_requirements_txt_path = maybe_requirements_txt_path(&module_directory);
+            imports.extend(maybe_requirements_txt_path);
+
+            // calculate the source hash
             let source_paths = iter::once(path.as_path())
                 .chain(imports.iter().map(|path| path.as_path()))
                 .collect::<Vec<_>>();
             let hash = calculate_source_hash(source_paths)?;
 
+            // return the Python module
             Ok(PythonModule::new(module_docs, functions, imports, hash))
         }
         Err(e) => Err(LoadPythonImportError::CouldNotLoadPythonModule(e)),
@@ -169,6 +175,14 @@ fn get_line_no(value: &Bound<'_, PyAny>, inspect_module: &Bound<'_, PyModule>) -
         .expect("`getsourcelines` should return a tuple of a string and a u32");
 
     Some(line_no)
+}
+
+fn maybe_requirements_txt_path(module_directory: &Path) -> Option<PathBuf> {
+    let requirements_txt_path = module_directory.join("requirements.txt");
+
+    requirements_txt_path
+        .exists()
+        .then_some(requirements_txt_path)
 }
 
 /// Tracks imports made by a Python module.

--- a/src-rs/oneil_python/src/load.rs
+++ b/src-rs/oneil_python/src/load.rs
@@ -2,6 +2,7 @@
 
 use std::{
     ffi::CString,
+    iter,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
@@ -18,6 +19,7 @@ use crate::{
     error::LoadPythonImportError,
     function::{PythonFunction, PythonModule},
     py_compat::oneil_python_module,
+    source_hash::calculate_source_hash,
 };
 
 pub fn load_python_import(
@@ -86,7 +88,12 @@ pub fn load_python_import(
     // return the functions
     match functions {
         Ok((module_docs, functions, imports)) => {
-            Ok(PythonModule::new(module_docs, functions, imports))
+            let source_paths = iter::once(path.as_path())
+                .chain(imports.iter().map(|path| path.as_path()))
+                .collect::<Vec<_>>();
+            let hash = calculate_source_hash(source_paths)?;
+
+            Ok(PythonModule::new(module_docs, functions, imports, hash))
         }
         Err(e) => Err(LoadPythonImportError::CouldNotLoadPythonModule(e)),
     }

--- a/src-rs/oneil_python/src/source_hash.rs
+++ b/src-rs/oneil_python/src/source_hash.rs
@@ -1,0 +1,41 @@
+use std::path::Path;
+
+use indexmap::IndexMap;
+use xxhash_rust::xxh3::Xxh3Default;
+
+use crate::LoadPythonImportError;
+
+pub fn calculate_source_hash(source_paths: Vec<&Path>) -> Result<u64, LoadPythonImportError> {
+    // sort the source paths to ensure consistent hashing
+    let mut source_paths = source_paths;
+    source_paths.sort_unstable(); // `Path` implements `Ord` correctly, so `unstable` is okay
+
+    // hash the source files
+
+    let mut builder = Xxh3Default::new();
+    let mut file_errors = IndexMap::new();
+
+    for source_path in source_paths {
+        let source = match std::fs::read_to_string(source_path) {
+            Ok(source) => source,
+            Err(e) => {
+                file_errors.insert(source_path.to_path_buf(), e);
+                continue;
+            }
+        };
+
+        builder.update(source.as_bytes());
+    }
+
+    // if there are any file errors, return an error
+    if !file_errors.is_empty() {
+        return Err(LoadPythonImportError::CouldNotCalculateSourceHash {
+            file_errors: Box::new(file_errors),
+        });
+    }
+
+    // digest the source files
+    let hash = builder.digest();
+
+    Ok(hash)
+}

--- a/src-rs/oneil_runtime/Cargo.toml
+++ b/src-rs/oneil_runtime/Cargo.toml
@@ -20,6 +20,7 @@ oneil_ir = { path = "../oneil_ir" }
 oneil_frontend = { path = "../oneil_frontend", default-features = false }
 oneil_output = { path = "../oneil_output" }
 oneil_parser = { path = "../oneil_parser" }
+oneil_py_call_cache = { path = "../oneil_py_call_cache", optional = true }
 oneil_python = { path = "../oneil_python", features = [
 	"rust-lib",
 ], optional = true }
@@ -28,7 +29,12 @@ indexmap = { workspace = true }
 
 [features]
 default = ["python"]
-python = ["oneil_python", "oneil_frontend/python", "oneil_eval/python"]
+python = [
+	"oneil_py_call_cache",
+	"oneil_python",
+	"oneil_frontend/python",
+	"oneil_eval/python",
+]
 
 [lints]
 workspace = true

--- a/src-rs/oneil_runtime/src/cache.rs
+++ b/src-rs/oneil_runtime/src/cache.rs
@@ -4,8 +4,6 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 
 use indexmap::IndexMap;
 use oneil_parser::error::ParserError;
-#[cfg(feature = "python")]
-use oneil_shared::paths::PythonPath;
 use oneil_shared::{
     EvalInstanceKey,
     load_result::LoadResult,
@@ -13,9 +11,6 @@ use oneil_shared::{
 };
 
 use crate::{error::SourceError, output};
-
-#[cfg(feature = "python")]
-use crate::error::PythonImportError;
 
 /// Content hash for cached source, used to detect when file contents change.
 pub fn source_hash(source: &str) -> u64 {
@@ -193,57 +188,6 @@ impl EvalCache {
     }
 }
 
-/// Cache for Python import function maps keyed by path.
-///
-/// Stores a [`Result`] per path: either the loaded [`PythonFunctionMap`] or a
-/// [`PythonImportError`](crate::error::PythonImportError) when loading failed.
-#[cfg(feature = "python")]
-#[derive(Debug)]
-pub struct PythonImportCache {
-    entries: IndexMap<PythonPath, Result<oneil_python::function::PythonModule, PythonImportError>>,
-}
-
-#[cfg(feature = "python")]
-impl Default for PythonImportCache {
-    fn default() -> Self {
-        Self {
-            entries: IndexMap::new(),
-        }
-    }
-}
-
-#[cfg(feature = "python")]
-impl PythonImportCache {
-    /// Creates an empty Python import cache.
-    #[must_use]
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Returns the full cached entry for `path`.
-    #[must_use]
-    pub fn get_entry(
-        &self,
-        path: &PythonPath,
-    ) -> Option<&Result<oneil_python::function::PythonModule, PythonImportError>> {
-        self.entries.get(path)
-    }
-
-    /// Inserts a result for `path`, replacing any existing entry.
-    pub fn insert(
-        &mut self,
-        path: PythonPath,
-        result: Result<oneil_python::function::PythonModule, PythonImportError>,
-    ) {
-        self.entries.insert(path, result);
-    }
-
-    /// Removes the cached entry for `path`, if present.
-    pub fn remove(&mut self, path: &PythonPath) {
-        self.entries.swap_remove(path);
-    }
-}
-
 /// Generic cache keyed by path, storing [`LoadResult<T, E>`] per path.
 ///
 /// Used to cache load outcomes (success, partial, or failure) for files or
@@ -282,5 +226,267 @@ impl<T, E> ModelCache<T, E> {
     /// Removes the cached entry for `path`, if present.
     pub fn remove(&mut self, path: &ModelPath) {
         self.entries.swap_remove(path);
+    }
+}
+
+#[cfg(feature = "python")]
+pub use python::{PythonCallCache, PythonImportCache};
+
+#[cfg(feature = "python")]
+mod python {
+    use std::path::{Component, PathBuf};
+
+    #[cfg(feature = "python")]
+    use indexmap::IndexMap;
+    use oneil_py_call_cache::{
+        FileCache, FunctionCall, FunctionCallResult, ReadCacheError, WriteCacheError,
+    };
+    use oneil_python::PythonEvalError;
+    #[cfg(feature = "python")]
+    use oneil_shared::paths::ModelPath;
+    use oneil_shared::{
+        paths::PythonPath,
+        symbols::{ParameterName, PyFunctionName, TestIndex},
+    };
+
+    use crate::error::PythonImportError;
+    #[cfg(feature = "python")]
+    use crate::output;
+    /// Cache for Python import function maps keyed by path.
+    ///
+    /// Stores a [`Result`] per path: either the loaded [`PythonFunctionMap`] or a
+    /// [`PythonImportError`](crate::error::PythonImportError) when loading failed.
+    #[cfg(feature = "python")]
+    #[derive(Debug)]
+    pub struct PythonImportCache {
+        entries:
+            IndexMap<PythonPath, Result<oneil_python::function::PythonModule, PythonImportError>>,
+    }
+
+    #[cfg(feature = "python")]
+    impl Default for PythonImportCache {
+        fn default() -> Self {
+            Self {
+                entries: IndexMap::new(),
+            }
+        }
+    }
+
+    #[cfg(feature = "python")]
+    impl PythonImportCache {
+        /// Creates an empty Python import cache.
+        #[must_use]
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        /// Returns the full cached entry for `path`.
+        #[must_use]
+        pub fn get_entry(
+            &self,
+            path: &PythonPath,
+        ) -> Option<&Result<oneil_python::function::PythonModule, PythonImportError>> {
+            self.entries.get(path)
+        }
+
+        /// Inserts a result for `path`, replacing any existing entry.
+        pub fn insert(
+            &mut self,
+            path: PythonPath,
+            result: Result<oneil_python::function::PythonModule, PythonImportError>,
+        ) {
+            self.entries.insert(path, result);
+        }
+
+        /// Removes the cached entry for `path`, if present.
+        pub fn remove(&mut self, path: &PythonPath) {
+            self.entries.swap_remove(path);
+        }
+    }
+
+    /// Cache for Python function calls keyed by path.
+    #[cfg(feature = "python")]
+    #[derive(Debug)]
+    pub struct PythonCallCache {
+        cache_dir: PathBuf,
+        entries: IndexMap<ModelPath, FileCache>,
+    }
+
+    #[cfg(feature = "python")]
+    impl PythonCallCache {
+        /// Creates an empty Python call cache.
+        #[must_use]
+        pub fn new(cache_dir: PathBuf) -> Self {
+            Self {
+                cache_dir,
+                entries: IndexMap::new(),
+            }
+        }
+
+        /// Clears the cache.
+        pub fn clear(&mut self) {
+            self.entries.clear();
+        }
+
+        /// Merges another cache into this one.
+        ///
+        /// If there are conflicting entries, the entries in the other cache are preferred.
+        pub fn merge(&mut self, other: Self) {
+            self.entries.extend(other.entries);
+        }
+
+        /// Returns the cached entry for `parameter` in `model_path`, if present.
+        ///
+        /// If the cache entry has not been loaded yet, it is loaded from disk.
+        ///
+        /// # Errors
+        ///
+        /// Returns [`ReadCacheError`] if the cache file cannot be read.
+        pub fn get_parameter_entry(
+            &mut self,
+            model_path: &ModelPath,
+            parameter_name: &ParameterName,
+        ) -> Option<&[FunctionCall]> {
+            self.load(model_path).ok()?;
+
+            let entry = self.entries.get(model_path)?;
+            entry.parameters.get(parameter_name).map(Vec::as_slice)
+        }
+
+        pub fn get_test_entry(
+            &mut self,
+            model_path: &ModelPath,
+            test_index: TestIndex,
+        ) -> Option<&[FunctionCall]> {
+            self.load(model_path).ok()?;
+
+            let entry = self.entries.get(model_path)?;
+            entry.tests.get(&test_index).map(Vec::as_slice)
+        }
+
+        pub fn add_parameter_entry(
+            &mut self,
+            model_path: &ModelPath,
+            parameter_name: &ParameterName,
+            function_name: &PyFunctionName,
+            args: &[output::Value],
+            eval_result: Result<output::Value, PythonEvalError>,
+        ) {
+            let entry = self.entries.entry(model_path.clone()).or_default();
+
+            let cached_eval_result = FunctionCallResult::from(eval_result);
+
+            entry
+                .parameters
+                .entry(parameter_name.clone())
+                .or_default()
+                .push(FunctionCall {
+                    function: function_name.clone(),
+                    inputs: args.to_vec(),
+                    output: cached_eval_result,
+                });
+        }
+
+        pub fn add_test_entry(
+            &mut self,
+            model_path: &ModelPath,
+            test_index: TestIndex,
+            function_name: &PyFunctionName,
+            args: &[output::Value],
+            eval_result: Result<output::Value, PythonEvalError>,
+        ) {
+            let entry = self.entries.entry(model_path.clone()).or_default();
+
+            let cached_eval_result = FunctionCallResult::from(eval_result);
+
+            entry
+                .tests
+                .entry(test_index)
+                .or_default()
+                .push(FunctionCall {
+                    function: function_name.clone(),
+                    inputs: args.to_vec(),
+                    output: cached_eval_result,
+                });
+        }
+
+        /// Loads a cache entry from disk.
+        ///
+        /// If the cache entry already exists, this does nothing.
+        ///
+        /// # Errors
+        ///
+        /// Returns [`ReadCacheError`] if the cache file cannot be read.
+        fn load(&mut self, model_path: &ModelPath) -> Result<(), ReadCacheError> {
+            if self.entries.contains_key(model_path) {
+                return Ok(());
+            }
+
+            let cache_relative_path = get_cache_relative_path(model_path);
+            let cache_path = self.cache_dir.join(cache_relative_path);
+            let cache = FileCache::read_from_path(cache_path)?;
+            self.entries.insert(model_path.clone(), cache);
+            Ok(())
+        }
+
+        /// Saves all cache entries to disk.
+        ///
+        /// # Errors
+        ///
+        /// Returns a vector of [`WriteCacheError`] if the cache files cannot be written.
+        pub fn save_all(&self) -> Result<(), Vec<WriteCacheError>> {
+            let mut errors = Vec::new();
+            for (model_path, cache) in &self.entries {
+                let cache_relative_path = get_cache_relative_path(model_path);
+                let cache_path = self.cache_dir.join(cache_relative_path);
+                match cache.write_to_path(cache_path) {
+                    Ok(()) => (),
+                    Err(e) => errors.push(e),
+                }
+            }
+
+            if errors.is_empty() {
+                Ok(())
+            } else {
+                Err(errors)
+            }
+        }
+    }
+
+    fn get_cache_relative_path(model_path: &ModelPath) -> PathBuf {
+        model_path
+            .as_path()
+            .with_extension("json")
+            .components()
+            // convert to a path that can be used in the cache directory
+            .fold(PathBuf::new(), append_normalized_component)
+    }
+
+    fn append_normalized_component(mut path: PathBuf, component: Component<'_>) -> PathBuf {
+        match component {
+            Component::Prefix(_) => {
+                path.push("__prefix__");
+            }
+            Component::RootDir => {
+                path.push("__root__");
+            }
+            Component::CurDir => {}
+            // in order to avoid overwriting files outside of the cache directory,
+            // we convert ".." to "__parent__"
+            Component::ParentDir => {
+                if let Some(parent) = path.parent()
+                    && !parent.ends_with("__parent__")
+                {
+                    path = parent.to_path_buf();
+                } else {
+                    path.push("__parent__");
+                }
+            }
+            Component::Normal(os_str) => {
+                path.push(os_str);
+            }
+        }
+
+        path
     }
 }

--- a/src-rs/oneil_runtime/src/cache.rs
+++ b/src-rs/oneil_runtime/src/cache.rs
@@ -484,6 +484,54 @@ mod python {
                 Err(errors)
             }
         }
+
+        /// Validates that the Python import for `model_path` is still valid by
+        /// checking the hash of the Python module.
+        ///
+        /// If the hash does not match, the Python import is cleared from the
+        /// cache and all cached function calls based on that import are cleared.
+        pub fn validate_or_clear_python_import(
+            &mut self,
+            model_path: &ModelPath,
+            python_path: &PythonPath,
+            python_module_hash: u64,
+        ) {
+            // make sure the model path has been loaded, if it exists
+            let Some(()) = self.load(model_path).ok() else {
+                return;
+            };
+
+            //
+            let Some(model_entry) = self.entries.get_mut(model_path) else {
+                return;
+            };
+
+            // get the import entry for the Python path
+            let Some(import_entry) = model_entry.imports.get(python_path) else {
+                return;
+            };
+
+            // check if the import entry is still valid by comparing the hash
+            if import_entry.hash == python_module_hash {
+                return;
+            }
+
+            // remove the import entry from the model entry
+            let Some(removed_import_entry) = model_entry.imports.remove(python_path) else {
+                return;
+            };
+
+            // remove cached function calls based on the functions from the removed import entry
+            let import_functions = removed_import_entry.functions_used;
+
+            for calls in model_entry.parameters.values_mut() {
+                calls.retain(|call| !import_functions.contains(&call.function));
+            }
+
+            for calls in model_entry.tests.values_mut() {
+                calls.retain(|call| !import_functions.contains(&call.function));
+            }
+        }
     }
 
     fn get_cache_relative_path(model_path: &ModelPath) -> PathBuf {

--- a/src-rs/oneil_runtime/src/cache.rs
+++ b/src-rs/oneil_runtime/src/cache.rs
@@ -230,19 +230,18 @@ impl<T, E> ModelCache<T, E> {
 }
 
 #[cfg(feature = "python")]
-pub use python::{PythonCallCache, PythonImportCache};
+pub use python::{PythonCallCache, PythonCallCacheRecord, PythonImportCache};
 
 #[cfg(feature = "python")]
 mod python {
     use std::path::{Component, PathBuf};
 
-    #[cfg(feature = "python")]
     use indexmap::IndexMap;
+    use oneil_py_call_cache::ImportEntry;
     use oneil_py_call_cache::{
-        FileCache, FunctionCall, FunctionCallResult, ReadCacheError, WriteCacheError,
+        FileCache, FunctionCall, FunctionCallResult, ImportHash, ReadCacheError, WriteCacheError,
     };
-    use oneil_python::PythonEvalError;
-    #[cfg(feature = "python")]
+    use oneil_python::{PythonEvalError, function::PythonModule};
     use oneil_shared::paths::ModelPath;
     use oneil_shared::{
         paths::PythonPath,
@@ -250,8 +249,31 @@ mod python {
     };
 
     use crate::error::PythonImportError;
-    #[cfg(feature = "python")]
     use crate::output;
+
+    /// Inputs shared by [`PythonCallCache::add_parameter_entry`] and [`PythonCallCache::add_test_entry`].
+    #[derive(Debug)]
+    pub struct PythonCallCacheRecord<'a> {
+        /// Model file whose cache entry is updated.
+        pub model_path: &'a ModelPath,
+        /// Path of the Python module that defined the callee.
+        pub python_path: &'a PythonPath,
+        /// Name of the invoked Python function.
+        pub function_name: &'a PyFunctionName,
+        /// Argument values passed to the call.
+        pub args: &'a [output::Value],
+        /// Evaluation outcome to persist.
+        pub eval_result: Result<output::Value, PythonEvalError>,
+        /// Loaded module metadata for import tracking.
+        pub python_module: &'a PythonModule,
+    }
+
+    /// Whether a recorded call belongs to a parameter default or a test body.
+    #[derive(Debug, Clone, Copy)]
+    enum CallCacheTarget<'a> {
+        Parameter(&'a ParameterName),
+        Test(TestIndex),
+    }
     /// Cache for Python import function maps keyed by path.
     ///
     /// Stores a [`Result`] per path: either the loaded [`PythonFunctionMap`] or a
@@ -364,50 +386,61 @@ mod python {
             entry.tests.get(&test_index).map(Vec::as_slice)
         }
 
+        /// Appends one cached function call for `parameter_name` and updates import usage.
         pub fn add_parameter_entry(
             &mut self,
-            model_path: &ModelPath,
+            record: PythonCallCacheRecord<'_>,
             parameter_name: &ParameterName,
-            function_name: &PyFunctionName,
-            args: &[output::Value],
-            eval_result: Result<output::Value, PythonEvalError>,
         ) {
-            let entry = self.entries.entry(model_path.clone()).or_default();
-
-            let cached_eval_result = FunctionCallResult::from(eval_result);
-
-            entry
-                .parameters
-                .entry(parameter_name.clone())
-                .or_default()
-                .push(FunctionCall {
-                    function: function_name.clone(),
-                    inputs: args.to_vec(),
-                    output: cached_eval_result,
-                });
+            self.push_function_call_entry(record, CallCacheTarget::Parameter(parameter_name));
         }
 
-        pub fn add_test_entry(
+        /// Appends one cached function call for `test_index` and updates import usage.
+        pub fn add_test_entry(&mut self, record: PythonCallCacheRecord<'_>, test_index: TestIndex) {
+            self.push_function_call_entry(record, CallCacheTarget::Test(test_index));
+        }
+
+        /// Appends one [`FunctionCall`] under `target` and registers `function_name` on the matching import entry.
+        fn push_function_call_entry(
             &mut self,
-            model_path: &ModelPath,
-            test_index: TestIndex,
-            function_name: &PyFunctionName,
-            args: &[output::Value],
-            eval_result: Result<output::Value, PythonEvalError>,
+            record: PythonCallCacheRecord<'_>,
+            target: CallCacheTarget<'_>,
         ) {
-            let entry = self.entries.entry(model_path.clone()).or_default();
+            let PythonCallCacheRecord {
+                model_path,
+                python_path,
+                function_name,
+                args,
+                eval_result,
+                python_module,
+            } = record;
 
-            let cached_eval_result = FunctionCallResult::from(eval_result);
+            let model_entry = self.entries.entry(model_path.clone()).or_default();
+            let cached_function_call = function_call_from(function_name, args, eval_result);
 
-            entry
-                .tests
-                .entry(test_index)
-                .or_default()
-                .push(FunctionCall {
-                    function: function_name.clone(),
-                    inputs: args.to_vec(),
-                    output: cached_eval_result,
-                });
+            match target {
+                CallCacheTarget::Parameter(parameter_name) => {
+                    model_entry
+                        .parameters
+                        .entry(parameter_name.clone())
+                        .or_default()
+                        .push(cached_function_call);
+                }
+                CallCacheTarget::Test(test_index) => {
+                    model_entry
+                        .tests
+                        .entry(test_index)
+                        .or_default()
+                        .push(cached_function_call);
+                }
+            }
+
+            model_entry
+                .imports
+                .entry(python_path.clone())
+                .or_insert_with(|| make_python_cache_import_entry(python_path, python_module))
+                .functions_used
+                .insert(function_name.clone());
         }
 
         /// Loads a cache entry from disk.
@@ -488,5 +521,37 @@ mod python {
         }
 
         path
+    }
+
+    fn function_call_from(
+        function_name: &PyFunctionName,
+        args: &[output::Value],
+        eval_result: Result<output::Value, PythonEvalError>,
+    ) -> FunctionCall {
+        FunctionCall {
+            function: function_name.clone(),
+            inputs: args.to_vec(),
+            output: FunctionCallResult::from(eval_result),
+        }
+    }
+
+    fn make_python_cache_import_entry(
+        python_path: &PythonPath,
+        python_module: &PythonModule,
+    ) -> ImportEntry {
+        let name = python_path
+            .as_path()
+            .file_stem()
+            .map_or_else(|| "<unknown>".into(), |s| s.to_string_lossy().to_string());
+
+        let dependencies = python_module
+            .get_imports()
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect();
+
+        let hash = ImportHash::from(python_module.get_hash());
+
+        ImportEntry::new(name, dependencies, hash)
     }
 }

--- a/src-rs/oneil_runtime/src/runtime/eval.rs
+++ b/src-rs/oneil_runtime/src/runtime/eval.rs
@@ -5,6 +5,8 @@ use std::path::PathBuf;
 use indexmap::IndexMap;
 use oneil_analysis::validate_instance_graph;
 use oneil_eval as eval;
+#[cfg(feature = "python")]
+use oneil_eval::CallsiteInfo;
 use oneil_frontend::{
     ApplyDesign, CompilationUnit, InstanceGraph, InstancedModel, ResolutionErrorCollection,
     apply_designs,
@@ -22,6 +24,8 @@ use oneil_shared::{
 use oneil_shared::{paths::PythonPath, symbols::PyFunctionName};
 
 use super::{Runtime, RuntimeBuiltinLookup};
+#[cfg(feature = "python")]
+use crate::cache::PythonCallCache;
 use crate::output::{self, error::RuntimeErrors};
 
 type EvalModelAndExpressionsResult<'runtime, 'expr> = (
@@ -252,8 +256,28 @@ impl Runtime {
             || !graph.contribution_errors.is_empty();
 
         if !has_blocking_errors {
+            // make sure the replacement cache is empty
+            #[cfg(feature = "python")]
+            self.python_call_replacement_cache.clear();
+
             // Evaluate the model and its dependencies
             let eval_result = eval::eval_model_from_graph(&graph, self);
+
+            #[cfg(feature = "python")]
+            {
+                // save the updated call cache
+                // TODO: handle errors from saving the replacement cache
+                self.python_call_replacement_cache
+                    .save_all()
+                    .expect("should be able to save the replacement cache");
+
+                // merge the replacement cache into the call cache
+                let replacement_cache = std::mem::replace(
+                    &mut self.python_call_replacement_cache,
+                    PythonCallCache::new(self.cache_dir.clone()),
+                );
+                self.python_call_cache.merge(replacement_cache);
+            }
 
             for (instance_key, maybe_partial) in eval_result {
                 match maybe_partial.into_result() {
@@ -433,13 +457,20 @@ impl eval::ExternalEvaluationContext for Runtime {
 
     #[cfg(feature = "python")]
     fn evaluate_imported_function(
-        &self,
+        &mut self,
         python_path: &PythonPath,
         identifier: &PyFunctionName,
         function_call_span: Span,
         args: Vec<(output::Value, Span)>,
+        callsite_info: &CallsiteInfo,
     ) -> Option<Result<output::Value, Box<EvalError>>> {
-        self.evaluate_python_function(python_path, identifier, function_call_span, args)
+        self.evaluate_python_function(
+            python_path,
+            identifier,
+            function_call_span,
+            args,
+            callsite_info,
+        )
     }
 
     fn lookup_unit(&self, name: &UnitBaseName) -> Option<&Unit> {

--- a/src-rs/oneil_runtime/src/runtime/mod.rs
+++ b/src-rs/oneil_runtime/src/runtime/mod.rs
@@ -21,8 +21,11 @@ mod util;
 mod python;
 
 #[cfg(feature = "python")]
-use crate::cache::PythonImportCache;
+use std::path::PathBuf;
+
 use crate::cache::{AstCache, EvalCache, SourceCache};
+#[cfg(feature = "python")]
+use crate::cache::{PythonCallCache, PythonImportCache};
 use indexmap::IndexMap;
 use oneil_builtins::BuiltinRef;
 use oneil_frontend::instance::graph::{ModelDesignInfo, UnitGraphCache};
@@ -50,6 +53,8 @@ impl BuiltinLookup for RuntimeBuiltinLookup<'_> {
 /// and evaluation results, and provides methods to load and process Oneil models.
 #[derive(Debug)]
 pub struct Runtime {
+    #[cfg(feature = "python")]
+    cache_dir: PathBuf,
     source_cache: SourceCache,
     ast_cache: AstCache,
     /// Per-compilation-unit instance graph cache. Each entry is the unit's
@@ -83,5 +88,9 @@ pub struct Runtime {
     composed_graph: Option<InstanceGraph>,
     #[cfg(feature = "python")]
     python_import_cache: PythonImportCache,
+    #[cfg(feature = "python")]
+    python_call_cache: PythonCallCache,
+    #[cfg(feature = "python")]
+    python_call_replacement_cache: PythonCallCache,
     builtins: BuiltinRef,
 }

--- a/src-rs/oneil_runtime/src/runtime/python.rs
+++ b/src-rs/oneil_runtime/src/runtime/python.rs
@@ -1,10 +1,15 @@
 //! Python import and evaluation for the runtime (when the `python` feature is enabled).
 
+use oneil_eval::CallsiteInfo;
 use oneil_output::EvalError;
 use oneil_python::{PythonEvalError, PythonFunction, function::PythonModule};
 
 use crate::error::PythonImportError;
-use oneil_shared::{paths::PythonPath, span::Span, symbols::PyFunctionName};
+use oneil_shared::{
+    paths::{ModelPath, PythonPath},
+    span::Span,
+    symbols::{ParameterName, PyFunctionName, TestIndex},
+};
 
 use super::Runtime;
 use crate::output::{self, error::RuntimeErrors};
@@ -93,12 +98,32 @@ impl Runtime {
 
     /// Evaluates a Python function by path and identifier.
     pub(super) fn evaluate_python_function(
-        &self,
+        &mut self,
         python_path: &PythonPath,
         identifier: &PyFunctionName,
         function_call_span: Span,
         args: Vec<(output::Value, Span)>,
+        callsite_info: &CallsiteInfo,
     ) -> Option<Result<output::Value, Box<EvalError>>> {
+        let args_no_spans: Vec<_> = args.clone().into_iter().map(|(value, _)| value).collect();
+        let cached_eval_result = match callsite_info {
+            CallsiteInfo::Parameter(instance_key, parameter_name) => self
+                .try_load_parameter_cache_entry(
+                    &instance_key.model_path,
+                    parameter_name,
+                    identifier,
+                    &args_no_spans,
+                ),
+            CallsiteInfo::Test(instance_key, test_index) => self.try_load_test_cache_entry(
+                &instance_key.model_path,
+                *test_index,
+                identifier,
+                &args_no_spans,
+            ),
+            // caching does not apply to other callsites
+            CallsiteInfo::Other => None,
+        };
+
         let python_functions = self
             .python_import_cache
             .get_entry(python_path)?
@@ -107,7 +132,30 @@ impl Runtime {
 
         let function = python_functions.get_function(identifier)?;
 
-        let eval_result = oneil_python::evaluate_python_function(function, args);
+        let eval_result = cached_eval_result
+            .unwrap_or_else(|| oneil_python::evaluate_python_function(function, args));
+
+        match callsite_info {
+            CallsiteInfo::Parameter(instance_key, parameter_name) => {
+                self.add_parameter_cache_entry(
+                    &instance_key.model_path,
+                    parameter_name,
+                    identifier,
+                    &args_no_spans,
+                    eval_result.clone(),
+                );
+            }
+            CallsiteInfo::Test(instance_key, test_index) => {
+                self.add_test_cache_entry(
+                    &instance_key.model_path,
+                    *test_index,
+                    identifier,
+                    &args_no_spans,
+                    eval_result.clone(),
+                );
+            }
+            CallsiteInfo::Other => (),
+        }
 
         Some(eval_result.map_err(|e| match e {
             PythonEvalError::PyErr { message, traceback } => Box::new(EvalError::PythonEvalError {
@@ -124,5 +172,73 @@ impl Runtime {
                 })
             }
         }))
+    }
+
+    fn try_load_parameter_cache_entry(
+        &mut self,
+        model_path: &ModelPath,
+        parameter_name: &ParameterName,
+        function_name: &PyFunctionName,
+        args: &[output::Value],
+    ) -> Option<Result<output::Value, PythonEvalError>> {
+        let calls = &self
+            .python_call_cache
+            .get_parameter_entry(model_path, parameter_name)?;
+
+        calls
+            .iter()
+            .find(|call| call.function == *function_name && call.inputs == args)
+            .map(|call| call.output.clone().into())
+    }
+
+    fn try_load_test_cache_entry(
+        &mut self,
+        model_path: &ModelPath,
+        test_index: TestIndex,
+        function_name: &PyFunctionName,
+        args: &[output::Value],
+    ) -> Option<Result<output::Value, PythonEvalError>> {
+        let calls = &self
+            .python_call_cache
+            .get_test_entry(model_path, test_index)?;
+
+        calls
+            .iter()
+            .find(|call| call.function == *function_name && call.inputs == args)
+            .map(|call| call.output.clone().into())
+    }
+
+    fn add_parameter_cache_entry(
+        &mut self,
+        model_path: &ModelPath,
+        parameter_name: &ParameterName,
+        function_name: &PyFunctionName,
+        args: &[output::Value],
+        eval_result: Result<output::Value, PythonEvalError>,
+    ) {
+        self.python_call_replacement_cache.add_parameter_entry(
+            model_path,
+            parameter_name,
+            function_name,
+            args,
+            eval_result,
+        );
+    }
+
+    fn add_test_cache_entry(
+        &mut self,
+        model_path: &ModelPath,
+        test_index: TestIndex,
+        function_name: &PyFunctionName,
+        args: &[output::Value],
+        eval_result: Result<output::Value, PythonEvalError>,
+    ) {
+        self.python_call_replacement_cache.add_test_entry(
+            model_path,
+            test_index,
+            function_name,
+            args,
+            eval_result,
+        );
     }
 }

--- a/src-rs/oneil_runtime/src/runtime/python.rs
+++ b/src-rs/oneil_runtime/src/runtime/python.rs
@@ -12,6 +12,7 @@ use oneil_shared::{
 };
 
 use super::Runtime;
+use crate::cache::PythonCallCacheRecord;
 use crate::output::{self, error::RuntimeErrors};
 
 impl Runtime {
@@ -140,6 +141,7 @@ impl Runtime {
                 self.add_parameter_cache_entry(
                     &instance_key.model_path,
                     parameter_name,
+                    python_path,
                     identifier,
                     &args_no_spans,
                     eval_result.clone(),
@@ -149,6 +151,7 @@ impl Runtime {
                 self.add_test_cache_entry(
                     &instance_key.model_path,
                     *test_index,
+                    python_path,
                     identifier,
                     &args_no_spans,
                     eval_result.clone(),
@@ -212,16 +215,27 @@ impl Runtime {
         &mut self,
         model_path: &ModelPath,
         parameter_name: &ParameterName,
+        python_path: &PythonPath,
         function_name: &PyFunctionName,
         args: &[output::Value],
         eval_result: Result<output::Value, PythonEvalError>,
     ) {
+        let python_module = self
+            .python_import_cache
+            .get_entry(python_path)
+            .and_then(|result| result.as_ref().ok())
+            .expect("should not be trying to add a parameter cache entry if the import failed");
+
         self.python_call_replacement_cache.add_parameter_entry(
-            model_path,
+            PythonCallCacheRecord {
+                model_path,
+                python_path,
+                function_name,
+                args,
+                eval_result,
+                python_module,
+            },
             parameter_name,
-            function_name,
-            args,
-            eval_result,
         );
     }
 
@@ -229,16 +243,27 @@ impl Runtime {
         &mut self,
         model_path: &ModelPath,
         test_index: TestIndex,
+        python_path: &PythonPath,
         function_name: &PyFunctionName,
         args: &[output::Value],
         eval_result: Result<output::Value, PythonEvalError>,
     ) {
+        let python_module = self
+            .python_import_cache
+            .get_entry(python_path)
+            .and_then(|result| result.as_ref().ok())
+            .expect("should not be trying to add a test cache entry if the import failed");
+
         self.python_call_replacement_cache.add_test_entry(
-            model_path,
+            PythonCallCacheRecord {
+                model_path,
+                python_path,
+                function_name,
+                args,
+                eval_result,
+                python_module,
+            },
             test_index,
-            function_name,
-            args,
-            eval_result,
         );
     }
 }

--- a/src-rs/oneil_runtime/src/runtime/python.rs
+++ b/src-rs/oneil_runtime/src/runtime/python.rs
@@ -112,12 +112,14 @@ impl Runtime {
                 .try_load_parameter_cache_entry(
                     &instance_key.model_path,
                     parameter_name,
+                    python_path,
                     identifier,
                     &args_no_spans,
                 ),
             CallsiteInfo::Test(instance_key, test_index) => self.try_load_test_cache_entry(
                 &instance_key.model_path,
                 *test_index,
+                python_path,
                 identifier,
                 &args_no_spans,
             ),
@@ -181,9 +183,22 @@ impl Runtime {
         &mut self,
         model_path: &ModelPath,
         parameter_name: &ParameterName,
+        python_path: &PythonPath,
         function_name: &PyFunctionName,
         args: &[output::Value],
     ) -> Option<Result<output::Value, PythonEvalError>> {
+        let python_module = self
+            .python_import_cache
+            .get_entry(python_path)
+            .and_then(|result| result.as_ref().ok())
+            .expect("should not be trying to load a parameter cache entry if the import failed");
+
+        self.python_call_cache.validate_or_clear_python_import(
+            model_path,
+            python_path,
+            python_module.get_hash(),
+        );
+
         let calls = &self
             .python_call_cache
             .get_parameter_entry(model_path, parameter_name)?;
@@ -198,9 +213,22 @@ impl Runtime {
         &mut self,
         model_path: &ModelPath,
         test_index: TestIndex,
+        python_path: &PythonPath,
         function_name: &PyFunctionName,
         args: &[output::Value],
     ) -> Option<Result<output::Value, PythonEvalError>> {
+        let python_module = self
+            .python_import_cache
+            .get_entry(python_path)
+            .and_then(|result| result.as_ref().ok())
+            .expect("should not be trying to load a test cache entry if the import failed");
+
+        self.python_call_cache.validate_or_clear_python_import(
+            model_path,
+            python_path,
+            python_module.get_hash(),
+        );
+
         let calls = &self
             .python_call_cache
             .get_test_entry(model_path, test_index)?;

--- a/src-rs/oneil_runtime/src/runtime/util.rs
+++ b/src-rs/oneil_runtime/src/runtime/util.rs
@@ -1,14 +1,17 @@
 //! Utility methods for the runtime.
 
+#[cfg(feature = "python")]
+use std::path::PathBuf;
+
 use indexmap::{IndexMap, IndexSet};
 #[cfg(feature = "python")]
 use oneil_shared::paths::PythonPath;
 use oneil_shared::paths::{ModelPath, SourcePath};
 
 use super::Runtime;
-#[cfg(feature = "python")]
-use crate::cache::PythonImportCache;
 use crate::cache::{AstCache, EvalCache, SourceCache};
+#[cfg(feature = "python")]
+use crate::cache::{PythonCallCache, PythonImportCache};
 use oneil_builtins::BuiltinRef;
 use oneil_frontend::instance::graph::UnitGraphCache;
 
@@ -16,7 +19,11 @@ impl Runtime {
     /// Creates a new runtime instance with empty caches.
     #[must_use]
     pub fn new() -> Self {
+        #[cfg(feature = "python")]
+        let cache_dir = PathBuf::from("__oncache__");
         Self {
+            #[cfg(feature = "python")]
+            cache_dir: cache_dir.clone(),
             source_cache: SourceCache::new(),
             ast_cache: AstCache::new(),
             unit_graph_cache: UnitGraphCache::new(),
@@ -25,6 +32,10 @@ impl Runtime {
             composed_graph: None,
             #[cfg(feature = "python")]
             python_import_cache: PythonImportCache::new(),
+            #[cfg(feature = "python")]
+            python_call_cache: PythonCallCache::new(cache_dir.clone()),
+            #[cfg(feature = "python")]
+            python_call_replacement_cache: PythonCallCache::new(cache_dir),
             builtins: BuiltinRef::new(),
         }
     }


### PR DESCRIPTION
_NOTE: This PR is dependent on [the JSON serialization structure](https://github.com/careweather/oneil/pull/42) and should not be reviewed until that PR is merged._

This PR implements caching for python function calls in Oneil. Caches are stored in `__oncache__` in the directory from which `oneil` is run.