### PR TITLE
Update cargo-fuzz install to be installed without using the lockfile

### DIFF
--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -56,7 +56,7 @@ jobs:
 
       # install cargo-fuzz
       - run: echo "${{ runner.tool_cache }}/cargo-fuzz/bin" >> $GITHUB_PATH
-      - run: cargo install --root "${{ runner.tool_cache }}/cargo-fuzz" --version ${{ env.CARGO_FUZZ_VERSION }} cargo-fuzz --locked
+      - run: cargo install --root "${{ runner.tool_cache }}/cargo-fuzz" --version ${{ env.CARGO_FUZZ_VERSION }} cargo-fuzz
 
       # Build and then run the fuzz target.
       - run: cargo fuzz build ${{ matrix.target }} --fuzz-dir src-rs/${{ matrix.crate }}/fuzz


### PR DESCRIPTION
This should fix broken fuzz tests.