### PR TITLE
Migration updates

### DIFF
--- a/src-rs/oneil_analysis/src/context.rs
+++ b/src-rs/oneil_analysis/src/context.rs
@@ -4,6 +4,7 @@ use indexmap::IndexMap;
 use oneil_frontend::InstancedModel;
 use oneil_output::{DependencySet, Model, Parameter, Test, Value};
 use oneil_shared::{
+    EvalInstanceKey,
     load_result::LoadResult,
     paths::ModelPath,
     symbols::{BuiltinValueName, ParameterName, TestIndex},
@@ -17,13 +18,13 @@ use crate::{
 
 /// External context provided to tree operations.
 pub trait ExternalAnalysisContext {
-    /// Returns the full map of model paths to their lowered [`InstancedModel`] templates.
-    fn get_all_model_ir(&self) -> IndexMap<&ModelPath, &InstancedModel>;
+    /// Returns the full map of evaluated instance keys to their lowered [`InstancedModel`]s.
+    fn get_all_model_ir(&self) -> IndexMap<EvalInstanceKey, &InstancedModel>;
 
     /// Returns the value of a builtin variable by identifier, if defined.
     fn lookup_builtin_variable(&self, identifier: &BuiltinValueName) -> Option<&Value>;
 
-    /// Looks up the evaluated model at the given path.
+    /// Looks up the evaluated root model at the given path.
     ///
     /// Returns `None` if the model is not in the context. Otherwise returns a
     /// [`LoadResult`]: success with the model reference, partial with the model and
@@ -33,23 +34,23 @@ pub trait ExternalAnalysisContext {
         model_path: &ModelPath,
     ) -> Option<LoadResult<&Model, ModelEvalHasErrors>>;
 
-    /// Looks up an evaluated parameter by model path and parameter name.
+    /// Looks up an evaluated parameter by instance key and parameter name.
     ///
     /// Returns `None` if the model is not in the context, `Some(Err(...))` on value errors,
     /// or `Some(Ok(parameter))` when the parameter is found.
     fn lookup_parameter_value(
         &self,
-        model_path: &ModelPath,
+        instance_key: &EvalInstanceKey,
         parameter_name: &ParameterName,
     ) -> Option<Result<Parameter, GetValueError>>;
 
-    /// Looks up an evaluated test by model path and test index.
+    /// Looks up an evaluated test by instance key and test index.
     ///
     /// Returns `None` if the model is not in the context, `Some(Err(...))` on lookup errors,
     /// or `Some(Ok(test))` when the test is found.
     fn lookup_test_value(
         &self,
-        model_path: &ModelPath,
+        instance_key: &EvalInstanceKey,
         test_index: TestIndex,
     ) -> Option<Result<Test, GetTestValueError>>;
 }
@@ -85,11 +86,11 @@ impl<'external, E: ExternalAnalysisContext> TreeContext<'external, E> {
     #[must_use]
     pub fn dependents(
         &self,
-        model_path: &ModelPath,
+        instance_key: &EvalInstanceKey,
         parameter_name: &ParameterName,
     ) -> DependencySet {
         self.dependency_graph
-            .dependents(model_path, parameter_name)
+            .dependents(instance_key, parameter_name)
             .cloned()
             .unwrap_or_default()
     }
@@ -98,11 +99,11 @@ impl<'external, E: ExternalAnalysisContext> TreeContext<'external, E> {
     #[must_use]
     pub fn references(
         &self,
-        model_path: &ModelPath,
+        instance_key: &EvalInstanceKey,
         parameter_name: &ParameterName,
     ) -> ReferenceSet {
         self.dependency_graph
-            .references(model_path, parameter_name)
+            .references(instance_key, parameter_name)
             .cloned()
             .unwrap_or_default()
     }
@@ -111,20 +112,20 @@ impl<'external, E: ExternalAnalysisContext> TreeContext<'external, E> {
     #[must_use]
     pub fn lookup_test_value(
         &self,
-        model_path: &ModelPath,
+        instance_key: &EvalInstanceKey,
         test_index: TestIndex,
     ) -> Option<Result<Test, GetTestValueError>> {
-        self.external.lookup_test_value(model_path, test_index)
+        self.external.lookup_test_value(instance_key, test_index)
     }
 
-    /// Looks up an evaluated parameter by model path and parameter name, delegating to the external context.
+    /// Looks up an evaluated parameter by instance key and parameter name, delegating to the external context.
     #[must_use]
     pub fn lookup_parameter_value(
         &self,
-        model_path: &ModelPath,
+        instance_key: &EvalInstanceKey,
         parameter_name: &ParameterName,
     ) -> Option<Result<Parameter, GetValueError>> {
         self.external
-            .lookup_parameter_value(model_path, parameter_name)
+            .lookup_parameter_value(instance_key, parameter_name)
     }
 }

--- a/src-rs/oneil_analysis/src/dep_graph.rs
+++ b/src-rs/oneil_analysis/src/dep_graph.rs
@@ -3,15 +3,15 @@
 use indexmap::{IndexMap, IndexSet};
 use oneil_output::{BuiltinDependency, DependencySet, ExternalDependency, ParameterDependency};
 use oneil_shared::{
-    paths::ModelPath,
+    EvalInstanceKey,
     symbols::{ParameterName, ReferenceName, TestIndex},
 };
 
 /// A dependency graph for the results of evaluating Oneil models.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DependencyGraph {
-    depends_on: IndexMap<ModelPath, IndexMap<ParameterName, DependencySet>>,
-    referenced_by: IndexMap<ModelPath, IndexMap<ParameterName, ReferenceSet>>,
+    depends_on: IndexMap<EvalInstanceKey, IndexMap<ParameterName, DependencySet>>,
+    referenced_by: IndexMap<EvalInstanceKey, IndexMap<ParameterName, ReferenceSet>>,
 }
 
 impl DependencyGraph {
@@ -27,12 +27,12 @@ impl DependencyGraph {
     /// Adds a builtin dependency to the graph.
     pub fn add_depends_on_builtin(
         &mut self,
-        param_path: ModelPath,
+        param_key: EvalInstanceKey,
         param_name: ParameterName,
         dependency: BuiltinDependency,
     ) {
         self.depends_on
-            .entry(param_path)
+            .entry(param_key)
             .or_default()
             .entry(param_name)
             .or_default()
@@ -43,12 +43,12 @@ impl DependencyGraph {
     /// Adds a parameter dependency to the graph.
     pub fn add_depends_on_parameter(
         &mut self,
-        param_path: ModelPath,
+        param_key: EvalInstanceKey,
         param_name: ParameterName,
         dependency: ParameterDependency,
     ) {
         self.depends_on
-            .entry(param_path.clone())
+            .entry(param_key.clone())
             .or_default()
             .entry(param_name.clone())
             .or_default()
@@ -64,7 +64,7 @@ impl DependencyGraph {
         };
 
         self.referenced_by
-            .entry(param_path)
+            .entry(param_key)
             .or_default()
             .entry(dependency_parameter_name)
             .or_default()
@@ -75,12 +75,12 @@ impl DependencyGraph {
     /// Adds an external dependency to the graph.
     pub fn add_depends_on_external(
         &mut self,
-        param_path: ModelPath,
+        param_key: EvalInstanceKey,
         param_name: ParameterName,
         dependency: ExternalDependency,
     ) {
         self.depends_on
-            .entry(param_path.clone())
+            .entry(param_key.clone())
             .or_default()
             .entry(param_name.clone())
             .or_default()
@@ -88,19 +88,19 @@ impl DependencyGraph {
             .insert(dependency.clone());
 
         let ExternalDependency {
-            model_path: dependency_model_path,
+            instance_key: dependency_instance_key,
             reference_name: dependency_reference_name,
             parameter_name: dependency_parameter_name,
         } = dependency;
 
         let reference = ExternalParameterReference {
-            model_path: param_path,
+            instance_key: param_key,
             parameter_name: param_name,
             using_reference_name: dependency_reference_name,
         };
 
         self.referenced_by
-            .entry(dependency_model_path)
+            .entry(dependency_instance_key)
             .or_default()
             .entry(dependency_parameter_name)
             .or_default()
@@ -111,7 +111,7 @@ impl DependencyGraph {
     /// Records that a test depends on another parameter in the same model, and the reverse edge.
     pub fn add_test_depends_on_parameter(
         &mut self,
-        model_path: ModelPath,
+        instance_key: EvalInstanceKey,
         test_index: TestIndex,
         dependency: ParameterDependency,
     ) {
@@ -122,7 +122,7 @@ impl DependencyGraph {
         let reference = TestReference { test_index };
 
         self.referenced_by
-            .entry(model_path)
+            .entry(instance_key)
             .or_default()
             .entry(dependency_parameter_name)
             .or_default()
@@ -133,24 +133,24 @@ impl DependencyGraph {
     /// Records that a test depends on a parameter in another model, and the reverse edge.
     pub fn add_test_depends_on_external(
         &mut self,
-        model_path: ModelPath,
+        instance_key: EvalInstanceKey,
         test_index: TestIndex,
         dependency: ExternalDependency,
     ) {
         let ExternalDependency {
-            model_path: dependency_model_path,
+            instance_key: dependency_instance_key,
             reference_name: dependency_reference_name,
             parameter_name: dependency_parameter_name,
         } = dependency;
 
         self.referenced_by
-            .entry(dependency_model_path)
+            .entry(dependency_instance_key)
             .or_default()
             .entry(dependency_parameter_name)
             .or_default()
             .external_test
             .insert(ExternalTestReference {
-                model_path,
+                instance_key,
                 test_index,
                 using_reference_name: dependency_reference_name,
             });
@@ -160,10 +160,10 @@ impl DependencyGraph {
     #[must_use]
     pub fn dependents(
         &self,
-        model_path: &ModelPath,
+        instance_key: &EvalInstanceKey,
         parameter_name: &ParameterName,
     ) -> Option<&DependencySet> {
-        let model = self.depends_on.get(model_path)?;
+        let model = self.depends_on.get(instance_key)?;
         model.get(parameter_name)
     }
 
@@ -171,10 +171,10 @@ impl DependencyGraph {
     #[must_use]
     pub fn references(
         &self,
-        model_path: &ModelPath,
+        instance_key: &EvalInstanceKey,
         parameter_name: &ParameterName,
     ) -> Option<&ReferenceSet> {
-        let model = self.referenced_by.get(model_path)?;
+        let model = self.referenced_by.get(instance_key)?;
         model.get(parameter_name)
     }
 }
@@ -236,8 +236,8 @@ pub struct ParameterReference {
 /// it indicates that a parameter in another model references this parameter.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ExternalParameterReference {
-    /// The path to the model that references this parameter.
-    pub model_path: ModelPath,
+    /// The evaluated model instance that references this parameter.
+    pub instance_key: EvalInstanceKey,
     /// The name of the parameter in the external model that references this parameter.
     pub parameter_name: ParameterName,
     /// The reference name used by the external model to access this model.
@@ -254,8 +254,8 @@ pub struct TestReference {
 /// A reference from a test in another model, via a reference import.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ExternalTestReference {
-    /// The path to the model that contains the test.
-    pub model_path: ModelPath,
+    /// The evaluated model instance that contains the test.
+    pub instance_key: EvalInstanceKey,
     /// The index of the test that references this parameter.
     pub test_index: TestIndex,
     /// The reference name the test's model uses for the model that defines this parameter.

--- a/src-rs/oneil_analysis/src/dependency.rs
+++ b/src-rs/oneil_analysis/src/dependency.rs
@@ -2,6 +2,7 @@
 
 use oneil_output::DependencySet;
 use oneil_shared::{
+    EvalInstanceKey,
     paths::ModelPath,
     symbols::{ParameterName, ReferenceName, TestIndex},
 };
@@ -16,7 +17,7 @@ use crate::{
 
 #[derive(Debug)]
 struct TreeValueLocation {
-    pub model_path: ModelPath,
+    pub instance_key: EvalInstanceKey,
     pub reference_name: Option<ReferenceName>,
     pub parameter_name: ParameterName,
 }
@@ -43,7 +44,7 @@ pub fn get_dependency_tree<E: ExternalAnalysisContext>(
     TreeErrors,
 ) {
     let location = TreeValueLocation {
-        model_path: model_path.clone(),
+        instance_key: EvalInstanceKey::root(model_path.clone()),
         reference_name: None,
         parameter_name: parameter_name.clone(),
     };
@@ -54,7 +55,7 @@ pub fn get_dependency_tree<E: ExternalAnalysisContext>(
         get_dependency_value,
         |location, tree_context| {
             get_dependency_tree_children(
-                &location.model_path,
+                &location.instance_key,
                 location.reference_name.as_ref(),
                 &location.parameter_name,
                 tree_context,
@@ -68,7 +69,7 @@ fn get_dependency_value<E: ExternalAnalysisContext>(
     tree_context: &TreeContext<'_, E>,
 ) -> Option<Result<output::DependencyTreeValue, GetValueError>> {
     let parameter =
-        tree_context.lookup_parameter_value(&location.model_path, &location.parameter_name)?;
+        tree_context.lookup_parameter_value(&location.instance_key, &location.parameter_name)?;
 
     let result = parameter.map(|parameter| {
         let dependency_name = location.reference_name.as_ref().map_or_else(
@@ -82,7 +83,10 @@ fn get_dependency_value<E: ExternalAnalysisContext>(
         );
 
         let parameter_value = parameter.value;
-        let display_info = Some((location.model_path.clone(), parameter.expr_span));
+        let display_info = Some((
+            location.instance_key.model_path.clone(),
+            parameter.expr_span,
+        ));
 
         output::DependencyTreeValue {
             dependency_name,
@@ -95,7 +99,7 @@ fn get_dependency_value<E: ExternalAnalysisContext>(
 }
 
 fn get_dependency_tree_children(
-    model_path: &ModelPath,
+    instance_key: &EvalInstanceKey,
     reference_name: Option<&ReferenceName>,
     parameter_name: &ParameterName,
     tree_context: &TreeContext<'_, impl ExternalAnalysisContext>,
@@ -104,7 +108,7 @@ fn get_dependency_tree_children(
         builtin_dependencies,
         parameter_dependencies,
         external_dependencies,
-    } = tree_context.dependents(model_path, parameter_name);
+    } = tree_context.dependents(instance_key, parameter_name);
 
     let builtin_children = builtin_dependencies
         .into_iter()
@@ -127,7 +131,7 @@ fn get_dependency_tree_children(
     let parameter_args = parameter_dependencies
         .into_iter()
         .map(|dep| TreeValueLocation {
-            model_path: model_path.clone(),
+            instance_key: instance_key.clone(),
             reference_name: reference_name.cloned(),
             parameter_name: dep.parameter_name,
         });
@@ -135,7 +139,7 @@ fn get_dependency_tree_children(
     let external_args = external_dependencies
         .into_iter()
         .map(|dep| TreeValueLocation {
-            model_path: dep.model_path.clone(),
+            instance_key: dep.instance_key.clone(),
             reference_name: Some(dep.reference_name.clone()),
             parameter_name: dep.parameter_name,
         });
@@ -161,7 +165,7 @@ pub fn get_reference_tree<E: ExternalAnalysisContext>(
     parameter_name: &ParameterName,
 ) -> (Option<output::Tree<output::ReferenceTreeValue>>, TreeErrors) {
     let location = TreeValueLocation {
-        model_path: model_path.clone(),
+        instance_key: EvalInstanceKey::root(model_path.clone()),
         reference_name: None,
         parameter_name: parameter_name.clone(),
     };
@@ -172,7 +176,7 @@ pub fn get_reference_tree<E: ExternalAnalysisContext>(
         get_reference_value,
         |location, tree_context| {
             get_reference_tree_children(
-                &location.model_path,
+                &location.instance_key,
                 &location.parameter_name,
                 tree_context,
             )
@@ -185,10 +189,10 @@ fn get_reference_value<E: ExternalAnalysisContext>(
     tree_context: &TreeContext<'_, E>,
 ) -> Option<Result<output::ReferenceTreeValue, GetValueError>> {
     let parameter =
-        tree_context.lookup_parameter_value(&location.model_path, &location.parameter_name)?;
+        tree_context.lookup_parameter_value(&location.instance_key, &location.parameter_name)?;
 
     let result = parameter.map(|parameter| {
-        let model_path = location.model_path.clone();
+        let model_path = location.instance_key.model_path.clone();
         let parameter_name = location.parameter_name.clone();
         let parameter_value = parameter.value;
         let display_info = (model_path.clone(), parameter.expr_span);
@@ -205,7 +209,7 @@ fn get_reference_value<E: ExternalAnalysisContext>(
 }
 
 fn get_reference_tree_children(
-    model_path: &ModelPath,
+    instance_key: &EvalInstanceKey,
     parameter_name: &ParameterName,
     tree_context: &TreeContext<'_, impl ExternalAnalysisContext>,
 ) -> GetChildrenResult<output::ReferenceTreeValue> {
@@ -214,10 +218,11 @@ fn get_reference_tree_children(
         Test(ModelPath, TestIndex),
     }
 
-    let deps = tree_context.references(model_path, parameter_name);
+    let deps = tree_context.references(instance_key, parameter_name);
+    let model_path = &instance_key.model_path;
 
     let parameter_children = deps.parameter.into_iter().map(|dep| TreeValueLocation {
-        model_path: model_path.clone(),
+        instance_key: instance_key.clone(),
         reference_name: None,
         parameter_name: dep.parameter_name,
     });
@@ -226,7 +231,7 @@ fn get_reference_tree_children(
         .external_parameter
         .into_iter()
         .map(|dep| TreeValueLocation {
-            model_path: dep.model_path,
+            instance_key: dep.instance_key,
             reference_name: None,
             parameter_name: dep.parameter_name,
         });
@@ -234,7 +239,7 @@ fn get_reference_tree_children(
     let all_param_children = parameter_children.chain(external_children).collect();
 
     let test_children = deps.test.iter().filter_map(|dep| {
-        let test = tree_context.lookup_test_value(model_path, dep.test_index)?;
+        let test = tree_context.lookup_test_value(instance_key, dep.test_index)?;
 
         let result = test
             .map(|test| {
@@ -257,24 +262,27 @@ fn get_reference_tree_children(
     });
 
     let test_external_children = deps.external_test.iter().filter_map(|dep| {
-        let test = tree_context.lookup_test_value(&dep.model_path, dep.test_index)?;
+        let test = tree_context.lookup_test_value(&dep.instance_key, dep.test_index)?;
 
         let result = test
             .map(|test| {
                 let test_passed = test.passed();
-                let display_info = (dep.model_path.clone(), test.expr_span);
+                let model_path = dep.instance_key.model_path.clone();
+                let display_info = (model_path.clone(), test.expr_span);
 
                 output::ReferenceTreeValue::Test {
-                    model_path: dep.model_path.clone(),
+                    model_path,
                     test_index: dep.test_index,
                     test_passed,
                     display_info,
                 }
             })
             .map_err(|error| match error {
-                GetTestValueError::Model => GetTestError::Model(dep.model_path.clone()),
+                GetTestValueError::Model => {
+                    GetTestError::Model(dep.instance_key.model_path.clone())
+                }
                 GetTestValueError::Test => {
-                    GetTestError::Test(dep.model_path.clone(), dep.test_index)
+                    GetTestError::Test(dep.instance_key.model_path.clone(), dep.test_index)
                 }
             });
 
@@ -353,14 +361,14 @@ where
             Ok(value) => value,
             Err(GetValueError::Model) => {
                 let mut tree_errors = TreeErrors::empty();
-                tree_errors.insert_model_error(location.model_path.clone());
+                tree_errors.insert_model_error(location.instance_key.model_path.clone());
 
                 return (None, tree_errors);
             }
             Err(GetValueError::Parameter) => {
                 let mut tree_errors = TreeErrors::empty();
                 tree_errors.insert_parameter_error(
-                    location.model_path.clone(),
+                    location.instance_key.model_path.clone(),
                     location.parameter_name.clone(),
                 );
 
@@ -412,30 +420,20 @@ fn get_dependency_graph<E: ExternalAnalysisContext>(
 ) -> crate::dep_graph::DependencyGraph {
     let mut dependency_graph = crate::dep_graph::DependencyGraph::new();
 
-    for (model_path, model) in external_context.get_all_model_ir() {
-        // Resolve the model path for an external `parameter.reference`
-        // dependency. The path is no longer stored in `Dependencies`
-        // (it is resolved lazily from the live instance graph), so we
-        // look it up from the model's own reference/submodel maps here.
-        let resolve_external_path = |reference_name: &oneil_shared::symbols::ReferenceName| {
-            model
-                .references()
-                .get(reference_name)
-                .map(|r| &r.path)
-                .or_else(|| {
-                    model
-                        .submodels()
-                        .get(reference_name)
-                        .map(|s| s.instance.path())
-                })
-        };
+    let all_model_ir = external_context.get_all_model_ir();
+
+    for (instance_key, model) in &all_model_ir {
+        let resolve_external_key =
+            |reference_name: &oneil_shared::symbols::ReferenceName| -> Option<EvalInstanceKey> {
+                resolve_external_instance_key(instance_key, model, &all_model_ir, reference_name)
+            };
 
         for (parameter_name, parameter) in model.parameters() {
             let dependencies = parameter.dependencies();
 
             for builtin_dep in dependencies.builtin().keys() {
                 dependency_graph.add_depends_on_builtin(
-                    model_path.clone(),
+                    instance_key.clone(),
                     parameter_name.clone(),
                     oneil_output::BuiltinDependency {
                         name: builtin_dep.clone(),
@@ -445,7 +443,7 @@ fn get_dependency_graph<E: ExternalAnalysisContext>(
 
             for parameter_dep in dependencies.parameter().keys() {
                 dependency_graph.add_depends_on_parameter(
-                    model_path.clone(),
+                    instance_key.clone(),
                     parameter_name.clone(),
                     oneil_output::ParameterDependency {
                         parameter_name: parameter_dep.clone(),
@@ -454,14 +452,14 @@ fn get_dependency_graph<E: ExternalAnalysisContext>(
             }
 
             for ((reference_dep_name, parameter_dep_name), _span) in dependencies.external() {
-                let Some(external_model_path) = resolve_external_path(reference_dep_name) else {
+                let Some(external_instance_key) = resolve_external_key(reference_dep_name) else {
                     continue;
                 };
                 dependency_graph.add_depends_on_external(
-                    model_path.clone(),
+                    instance_key.clone(),
                     parameter_name.clone(),
                     oneil_output::ExternalDependency {
-                        model_path: external_model_path.clone(),
+                        instance_key: external_instance_key,
                         reference_name: reference_dep_name.clone(),
                         parameter_name: parameter_dep_name.clone(),
                     },
@@ -474,7 +472,7 @@ fn get_dependency_graph<E: ExternalAnalysisContext>(
 
             for parameter_dep in dependencies.parameter().keys() {
                 dependency_graph.add_test_depends_on_parameter(
-                    model_path.clone(),
+                    instance_key.clone(),
                     *test_index,
                     oneil_output::ParameterDependency {
                         parameter_name: parameter_dep.clone(),
@@ -483,14 +481,14 @@ fn get_dependency_graph<E: ExternalAnalysisContext>(
             }
 
             for ((reference_dep_name, parameter_dep_name), _span) in dependencies.external() {
-                let Some(external_model_path) = resolve_external_path(reference_dep_name) else {
+                let Some(external_instance_key) = resolve_external_key(reference_dep_name) else {
                     continue;
                 };
                 dependency_graph.add_test_depends_on_external(
-                    model_path.clone(),
+                    instance_key.clone(),
                     *test_index,
                     oneil_output::ExternalDependency {
-                        model_path: external_model_path.clone(),
+                        instance_key: external_instance_key,
                         reference_name: reference_dep_name.clone(),
                         parameter_name: parameter_dep_name.clone(),
                     },
@@ -500,4 +498,52 @@ fn get_dependency_graph<E: ExternalAnalysisContext>(
     }
 
     dependency_graph
+}
+
+/// Resolves a reference name from an instanced IR node to the evaluated instance key it targets.
+fn resolve_external_instance_key(
+    instance_key: &EvalInstanceKey,
+    model: &oneil_frontend::InstancedModel,
+    all_model_ir: &indexmap::IndexMap<EvalInstanceKey, &oneil_frontend::InstancedModel>,
+    reference_name: &ReferenceName,
+) -> Option<EvalInstanceKey> {
+    if let Some(reference) = model.references().get(reference_name) {
+        return Some(EvalInstanceKey::root(reference.path.clone()));
+    }
+
+    if let Some(submodel) = model.submodels().get(reference_name) {
+        return Some(EvalInstanceKey {
+            model_path: submodel.instance.path().clone(),
+            instance_path: instance_key
+                .instance_path
+                .clone()
+                .child(reference_name.clone()),
+        });
+    }
+
+    let alias = model.aliases().get(reference_name)?;
+    let mut segments = alias.alias_path.segments().iter();
+    let first = segments.next()?;
+
+    let mut current_key = if let Some(submodel) = model.submodels().get(first) {
+        EvalInstanceKey {
+            model_path: submodel.instance.path().clone(),
+            instance_path: instance_key.instance_path.clone().child(first.clone()),
+        }
+    } else if let Some(reference) = model.references().get(first) {
+        EvalInstanceKey::root(reference.path.clone())
+    } else {
+        return None;
+    };
+
+    for segment in segments {
+        let current_model = all_model_ir.get(&current_key)?;
+        let submodel = current_model.submodels().get(segment)?;
+        current_key = EvalInstanceKey {
+            model_path: submodel.instance.path().clone(),
+            instance_path: current_key.instance_path.child(segment.clone()),
+        };
+    }
+
+    Some(current_key)
 }

--- a/src-rs/oneil_cli/src/command.rs
+++ b/src-rs/oneil_cli/src/command.rs
@@ -239,6 +239,13 @@ pub struct EvalArgs {
     #[arg(long)]
     pub with_test_report: bool,
 
+    /// Do not print failing test output at all during eval
+    ///
+    /// When provided, this suppresses both the failing test hint and
+    /// `--with-test-report` output.
+    #[arg(long)]
+    pub ignore_failing_tests: bool,
+
     #[command(flatten)]
     pub common: CommonArgs,
 }

--- a/src-rs/oneil_cli/src/lib.rs
+++ b/src-rs/oneil_cli/src/lib.rs
@@ -438,6 +438,7 @@ fn handle_eval_command(args: EvalArgs) {
         recursive,
         with_header,
         with_test_report,
+        ignore_failing_tests,
         common,
     } = args;
 
@@ -459,6 +460,7 @@ fn handle_eval_command(args: EvalArgs) {
         recursive,
         with_header,
         with_test_report,
+        ignore_failing_tests,
         print_utils_config,
         hint_path,
     };

--- a/src-rs/oneil_cli/src/print_model_result.rs
+++ b/src-rs/oneil_cli/src/print_model_result.rs
@@ -25,6 +25,7 @@ pub struct ModelPrintConfig {
     pub recursive: bool,
     pub with_header: bool,
     pub with_test_report: bool,
+    pub ignore_failing_tests: bool,
     pub print_utils_config: PrintUtilsConfig,
     /// Path to show in the "Run `oneil test <path>`" hint.
     /// When running a design file, this should be the design path.
@@ -45,7 +46,7 @@ pub fn print_eval_result(
         print_model_header(model_result.path(), &test_info);
     }
 
-    if test_info.passed_count != test_info.test_count {
+    if !model_config.ignore_failing_tests && test_info.passed_count != test_info.test_count {
         if model_config.with_test_report {
             println!("{divider_line}");
             print_failing_tests(&test_info, model_config.print_utils_config);

--- a/src-rs/oneil_cli/src/print_tree.rs
+++ b/src-rs/oneil_cli/src/print_tree.rs
@@ -156,7 +156,7 @@ fn print_children<T: PrintableTreeValue>(
         || (!config.recursive && value.is_outside_top_model(context.top_model_path));
 
     if has_children && skip_printing_children {
-        print_truncated_node(indent, rest_prefix);
+        print_truncated_node(indent, rest_prefix, context.is_first);
     } else if has_children {
         parent_prefixes.push(context.is_first);
 
@@ -247,8 +247,12 @@ fn get_equation_str(
         })
 }
 
-fn print_truncated_node(indent: &str, rest_prefix: &str) {
-    println!("{indent}{rest_prefix}┌──╶╶╶");
+fn print_truncated_node(indent: &str, rest_prefix: &str, is_first: bool) {
+    if is_first {
+        println!("{indent}    ┌──╶╶╶");
+    } else {
+        println!("{indent}{rest_prefix}┌──╶╶╶");
+    }
 }
 
 trait PrintableTreeValue {

--- a/src-rs/oneil_eval/src/context.rs
+++ b/src-rs/oneil_eval/src/context.rs
@@ -557,16 +557,18 @@ impl<'external, E: ExternalEvaluationContext> EvalContext<'external, E> {
         self.force_parameter(&current_key, parameter_name, variable_span, &current_key)
     }
 
-    /// Returns the model path of the instance reached via `reference_name` from the active model.
+    /// Returns the instance key reached via `reference_name` from the active model.
     ///
-    /// Used when building `ExternalDependency` output where the model path is needed but
+    /// Used when building `ExternalDependency` output where the instance key is needed but
     /// is no longer stored in `Variable::External`.
     #[must_use]
-    pub fn lookup_external_model_path(&self, reference_name: &ReferenceName) -> Option<ModelPath> {
+    pub fn lookup_external_instance_key(
+        &self,
+        reference_name: &ReferenceName,
+    ) -> Option<EvalInstanceKey> {
         let current = self.eval_scope.last()?;
         let model = self.models.get(current)?;
-        let key = model.references.get(reference_name)?;
-        Some(key.model_path.clone())
+        model.references.get(reference_name).cloned()
     }
 
     /// Looks up a parameter on the instance reached via `reference_name` from the active model,

--- a/src-rs/oneil_eval/src/eval_parameter.rs
+++ b/src-rs/oneil_eval/src/eval_parameter.rs
@@ -844,11 +844,11 @@ pub fn build_output_parameter<E: ExternalEvaluationContext>(
         .external()
         .keys()
         .filter_map(|(reference_name, parameter_name)| {
-            // Model path is looked up from the live eval context since it is no
+            // Instance key is looked up from the live eval context since it is no
             // longer stored in `ir::Variable::External`.
-            let model_path = context.lookup_external_model_path(reference_name)?;
+            let instance_key = context.lookup_external_instance_key(reference_name)?;
             Some(ExternalDependency {
-                model_path,
+                instance_key,
                 reference_name: reference_name.clone(),
                 parameter_name: parameter_name.clone(),
             })

--- a/src-rs/oneil_output/src/dependency.rs
+++ b/src-rs/oneil_output/src/dependency.rs
@@ -2,7 +2,7 @@
 
 use indexmap::IndexSet;
 use oneil_shared::{
-    paths::ModelPath,
+    EvalInstanceKey,
     symbols::{BuiltinValueName, ParameterName, ReferenceName},
 };
 
@@ -59,8 +59,8 @@ pub struct ParameterDependency {
 /// accessed through model references. These create cross-model dependency relationships.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ExternalDependency {
-    /// The path to the external model containing the parameter.
-    pub model_path: ModelPath,
+    /// The evaluated model instance containing the parameter.
+    pub instance_key: EvalInstanceKey,
     /// The reference name used to access the external model.
     pub reference_name: ReferenceName,
     /// The name of the parameter in the external model.

--- a/src-rs/oneil_runtime/src/runtime/analysis.rs
+++ b/src-rs/oneil_runtime/src/runtime/analysis.rs
@@ -10,6 +10,7 @@ use oneil_analysis::{
 };
 use oneil_frontend::{CompilationUnit, InstancedModel};
 use oneil_shared::{
+    EvalInstanceKey,
     load_result::LoadResult,
     paths::ModelPath,
     symbols::{BuiltinValueName, ParameterName, TestIndex},
@@ -128,17 +129,28 @@ impl Runtime {
 }
 
 impl analysis::ExternalAnalysisContext for Runtime {
-    fn get_all_model_ir(&self) -> IndexMap<&ModelPath, &InstancedModel> {
+    fn get_all_model_ir(&self) -> IndexMap<EvalInstanceKey, &InstancedModel> {
         self.unit_graph_cache
             .iter()
-            .filter_map(|(unit, graph)| {
-                let CompilationUnit::Model(path) = unit else {
-                    return None;
-                };
-                let template: &InstancedModel = graph.root.as_ref();
-                Some((path, template))
+            .fold(IndexMap::new(), |mut instances, (unit, graph)| {
+                if let CompilationUnit::Model(path) = unit {
+                    insert_model_ir_subtree(
+                        graph.root.as_ref(),
+                        &EvalInstanceKey::root(path.clone()),
+                        &mut instances,
+                    );
+
+                    for (path, instance) in &graph.reference_pool {
+                        insert_model_ir_subtree(
+                            instance.as_ref(),
+                            &EvalInstanceKey::root(path.clone()),
+                            &mut instances,
+                        );
+                    }
+                }
+
+                instances
             })
-            .collect()
     }
 
     fn get_evaluated_model(
@@ -159,10 +171,10 @@ impl analysis::ExternalAnalysisContext for Runtime {
 
     fn lookup_parameter_value(
         &self,
-        model_path: &ModelPath,
+        instance_key: &EvalInstanceKey,
         parameter_name: &ParameterName,
     ) -> Option<Result<oneil_output::Parameter, oneil_analysis::output::error::GetValueError>> {
-        let entry = self.eval_cache.get_entry(model_path)?;
+        let entry = self.eval_cache.get_entry_instance(instance_key)?;
         let parameter = entry.value().map_or_else(
             || Err(oneil_analysis::output::error::GetValueError::Model),
             |model| {
@@ -179,10 +191,10 @@ impl analysis::ExternalAnalysisContext for Runtime {
 
     fn lookup_test_value(
         &self,
-        model_path: &ModelPath,
+        instance_key: &EvalInstanceKey,
         test_index: TestIndex,
     ) -> Option<Result<oneil_output::Test, oneil_analysis::output::error::GetTestValueError>> {
-        let entry = self.eval_cache.get_entry(model_path)?;
+        let entry = self.eval_cache.get_entry_instance(instance_key)?;
         let test = entry.value().map_or_else(
             || Err(oneil_analysis::output::error::GetTestValueError::Model),
             |model| {
@@ -195,5 +207,25 @@ impl analysis::ExternalAnalysisContext for Runtime {
         );
 
         Some(test)
+    }
+}
+
+/// Inserts an instanced model and its owned submodel descendants keyed by eval instance.
+fn insert_model_ir_subtree<'model>(
+    instance: &'model InstancedModel,
+    instance_key: &EvalInstanceKey,
+    instances: &mut IndexMap<EvalInstanceKey, &'model InstancedModel>,
+) {
+    instances.insert(instance_key.clone(), instance);
+
+    for (alias, submodel) in instance.submodels() {
+        insert_model_ir_subtree(
+            submodel.instance.as_ref(),
+            &EvalInstanceKey {
+                model_path: submodel.instance.path().clone(),
+                instance_path: instance_key.instance_path.clone().child(alias.clone()),
+            },
+            instances,
+        );
     }
 }

--- a/src-rs/oneil_runtime/src/runtime/error.rs
+++ b/src-rs/oneil_runtime/src/runtime/error.rs
@@ -112,6 +112,7 @@ impl Runtime {
         visited: &mut IndexSet<EvalInstanceKey>,
     ) -> RuntimeErrors {
         let model_path = &eval_instance_key.model_path;
+
         if !visited.insert(eval_instance_key.clone()) {
             return RuntimeErrors::default();
         }
@@ -162,10 +163,11 @@ impl Runtime {
         let ir_errors = ir_error_collection
             .map(|errors| collect_ir_errors(errors, model_path, source, include_indirect_errors));
 
-        let raw_validation_errors: Option<Vec<InstanceValidationError>> = self
+        let (raw_validation_errors, other_models_with_validation_errors) = self
             .composed_graph
             .as_ref()
-            .map(|graph| collect_validation_errors_from_graph(graph, model_path));
+            .map(|graph| collect_validation_errors_from_graph(graph, model_path))
+            .unzip();
         let cycle_param_names: IndexSet<ParameterName> = raw_validation_errors
             .as_deref()
             .map(parameter_cycle_names)
@@ -179,6 +181,11 @@ impl Runtime {
                 &self.source_cache,
             )
         });
+        let other_models_with_validation_errors = other_models_with_validation_errors
+            .into_iter()
+            .flatten()
+            .map(EvalInstanceKey::root)
+            .collect::<IndexSet<_>>();
 
         // get the eval errors, if any. Eval-time `CircularParameterEvaluation`
         // is suppressed for parameters that the graph-time SCC pass already
@@ -271,6 +278,7 @@ impl Runtime {
         let model_references = models_with_errors
             .iter()
             .chain(model_successful_references)
+            .chain(other_models_with_validation_errors.iter())
             .collect::<IndexSet<_>>();
 
         for eval_instance_key in model_references {
@@ -1119,13 +1127,23 @@ fn get_python_path_from_python_import_error(
 fn collect_validation_errors_from_graph(
     graph: &InstanceGraph,
     model_path: &ModelPath,
-) -> Vec<InstanceValidationError> {
-    graph
+) -> (Vec<InstanceValidationError>, IndexSet<ModelPath>) {
+    let (current_model_errors, other_model_errors): (Vec<_>, Vec<_>) = graph
         .validation_errors
         .iter()
-        .filter(|e| host_path_model(graph, &e.host_path) == Some(model_path))
+        .partition(|e| host_path_model(graph, &e.host_path) == Some(model_path));
+
+    let current_model_errors = current_model_errors
+        .into_iter()
         .cloned()
-        .collect()
+        .collect::<Vec<_>>();
+
+    let other_models_with_errors = other_model_errors
+        .iter()
+        .filter_map(|e| host_path_model(graph, &e.host_path).cloned())
+        .collect::<IndexSet<_>>();
+
+    (current_model_errors, other_models_with_errors)
 }
 
 /// Returns the [`ModelPath`] of the host node identified by `host_path` in

--- a/src-rs/oneil_shared/src/span/mod.rs
+++ b/src-rs/oneil_shared/src/span/mod.rs
@@ -1,6 +1,6 @@
 //! Source location spans for mapping data structures to source code
 
-use std::{path::Path, sync::Arc};
+use std::{fmt, path::Path, sync::Arc};
 
 /// A span of source code.
 ///
@@ -16,7 +16,7 @@ use std::{path::Path, sync::Arc};
 /// parameter equation.
 ///
 /// Because [`Rc`] is not [`Copy`], `Span` is deliberately `Clone`-only.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[derive(Clone, PartialEq, Eq, serde::Serialize)]
 pub struct Span {
     start: SourceLocation,
     end: SourceLocation,
@@ -161,6 +161,23 @@ impl Span {
         };
 
         Self::new(start_loc, end_loc, Arc::from(Path::new("")), Arc::from(""))
+    }
+}
+
+/// Formats the span as `path:line:column`. Debug output is formatted in a way
+/// that consoles can pick up as a clickable link to the source code.
+///
+/// This excludes the source text from the output, since it is not directly
+/// relevant to the span in terms of debugging.
+impl fmt::Debug for Span {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}:{}:{}",
+            self.path.display(),
+            self.start.line,
+            self.start.column
+        )
     }
 }
 


### PR DESCRIPTION
Updates to Oneil that I implemented while doing Veery migration. Implementing a custom span debug and the test hint flag aren't essential, but error handling, tree printing, and the dependecy analysis fix are all bug fixes that we should probably get into Oneil ASAP.