### PR TITLE
fix(parser): Allow for whitespace without a newline at the beginning of a file

### DIFF
--- a/src-rs/oneil_parser/src/model.rs
+++ b/src-rs/oneil_parser/src/model.rs
@@ -28,7 +28,11 @@ use crate::{
         reason::{ExpectKind, ParserErrorReason},
     },
     note::parse as parse_note,
-    token::{keyword::section, naming::label, structure::end_of_line},
+    token::{
+        keyword::section,
+        naming::label,
+        structure::{end_of_line, start_of_file},
+    },
     util::{InputSpan, Result, source_location_from},
 };
 
@@ -61,7 +65,7 @@ fn model(input: InputSpan<'_>) -> Result<'_, ModelNode, Box<ParserPartialModelEr
     // Capture the start location before consuming input.
     let model_span_start = source_location_from(&input);
 
-    let (rest, end_of_line_token) = opt(end_of_line).parse(input).expect("should always parse");
+    let (rest, start_of_file_token) = start_of_file(input).expect("should always parse");
 
     let (rest, note) = opt(parse_note)
         .parse(rest.clone())
@@ -76,8 +80,10 @@ fn model(input: InputSpan<'_>) -> Result<'_, ModelNode, Box<ParserPartialModelEr
     let errors = [decl_errors, section_errors].concat();
 
     // get the last span/whitespace span of the model
-    let last_end_of_line_spans =
-        end_of_line_token.map(|token| (token.lexeme_span, token.whitespace_span));
+    let start_of_file_spans = (
+        start_of_file_token.lexeme_span,
+        start_of_file_token.whitespace_span,
+    );
     let last_note_spans = note
         .as_ref()
         .map(|note| (note.span().clone(), note.whitespace_span().clone()));
@@ -88,25 +94,21 @@ fn model(input: InputSpan<'_>) -> Result<'_, ModelNode, Box<ParserPartialModelEr
         .last()
         .map(|section| (section.span().clone(), section.whitespace_span().clone()));
 
-    let (last_node_span, last_node_whitespace_span) = [
-        last_end_of_line_spans,
-        last_note_spans,
-        last_decl_spans,
-        last_section_spans,
-    ]
-    .into_iter()
-    .flatten()
-    .max_by(|a, b| {
-        let a_end = a.0.end();
-        let b_end = b.0.end();
-        a_end
-            .partial_cmp(b_end)
-            .expect("should always compare because they are from the same file")
-    })
-    .unzip();
+    let (last_node_span, last_node_whitespace_span) =
+        [last_note_spans, last_decl_spans, last_section_spans]
+            .into_iter()
+            .flatten()
+            .max_by(|a, b| {
+                let a_end = a.0.end();
+                let b_end = b.0.end();
+                a_end
+                    .partial_cmp(b_end)
+                    .expect("should always compare because they are from the same file")
+            })
+            .unwrap_or(start_of_file_spans);
 
     // calculate the end of the model span
-    let model_span_end = last_node_span.map_or(model_span_start, |span| *span.end());
+    let model_span_end = *last_node_span.end();
 
     // build the model span
     let model_span = Span::new(
@@ -118,8 +120,7 @@ fn model(input: InputSpan<'_>) -> Result<'_, ModelNode, Box<ParserPartialModelEr
 
     // calculate the whitespace span of the model
     // (if there was no last node, use the model span)
-    let model_whitespace_span = last_node_whitespace_span
-        .unwrap_or_else(|| Span::new(*model_span.end(), *model_span.end(), path, source));
+    let model_whitespace_span = last_node_whitespace_span;
 
     let model_node = Node::new(
         Model::new(note, decls, sections),

--- a/src-rs/oneil_parser/src/token/structure.rs
+++ b/src-rs/oneil_parser/src/token/structure.rs
@@ -39,6 +39,37 @@ fn comment(input: InputSpan<'_>) -> Result<'_, InputSpan<'_>, TokenError> {
     recognize((char('#'), not_line_ending, line_ending.or(eof))).parse(input)
 }
 
+/// Parses optional leading content at the start of a file.
+///
+/// This function recognizes any combination of:
+/// - Inline whitespace (spaces and tabs)
+/// - End-of-line markers (line breaks, comments, end-of-file)
+///
+/// Unlike [`end_of_line`], leading inline whitespace is accepted before
+/// end-of-line markers. This parser always succeeds.
+pub fn start_of_file(input: InputSpan<'_>) -> Result<'_, Token<'_>, TokenError> {
+    let lexeme_str = &input.fragment()[..0];
+    let lexeme_span = span_from(&input, &input);
+
+    let (rest, whitespace) = recognize(|input| {
+        let (rest, _) = inline_whitespace.parse(input)?;
+        let (rest, _) = opt(end_of_line).parse(rest)?;
+        Ok((rest, ()))
+    })
+    .parse(input)?;
+
+    let whitespace_span = span_from(&whitespace, &rest);
+
+    Ok((
+        rest,
+        Token {
+            lexeme_str,
+            lexeme_span,
+            whitespace_span,
+        },
+    ))
+}
+
 /// Parses one or more linebreaks, comments, or end-of-file markers, including trailing whitespace.
 ///
 /// This function recognizes any combination of:
@@ -324,6 +355,79 @@ mod tests {
             };
 
             assert!(matches!(token_error.kind, TokenErrorKind::NomError(_)));
+        }
+    }
+
+    mod start_of_file {
+        use super::*;
+
+        #[test]
+        fn empty_input() {
+            let input = InputSpan::new_extra("", Config::default());
+            let (rest, matched) = start_of_file(input).expect("should parse empty input");
+            assert_eq!(rest.fragment(), &"");
+            assert_eq!(matched.lexeme_str, "");
+        }
+
+        #[test]
+        fn no_leading_content() {
+            let input = InputSpan::new_extra("param = 1", Config::default());
+            let (rest, matched) =
+                start_of_file(input).expect("should parse with no leading content");
+            assert_eq!(rest.fragment(), &"param = 1");
+            assert_eq!(matched.lexeme_str, "");
+        }
+
+        #[test]
+        fn leading_inline_whitespace() {
+            let input = InputSpan::new_extra("   param = 1", Config::default());
+            let (rest, matched) =
+                start_of_file(input).expect("should parse leading inline whitespace");
+            assert_eq!(rest.fragment(), &"param = 1");
+            assert_eq!(matched.lexeme_str, "");
+        }
+
+        #[test]
+        fn leading_end_of_line() {
+            let input = InputSpan::new_extra("\nparam = 1", Config::default());
+            let (rest, matched) = start_of_file(input).expect("should parse leading end of line");
+            assert_eq!(rest.fragment(), &"param = 1");
+            assert_eq!(matched.lexeme_str, "");
+        }
+
+        #[test]
+        fn leading_inline_whitespace_before_end_of_line() {
+            let input = InputSpan::new_extra("   \nparam = 1", Config::default());
+            let (rest, matched) =
+                start_of_file(input).expect("should parse whitespace before end of line");
+            assert_eq!(rest.fragment(), &"param = 1");
+            assert_eq!(matched.lexeme_str, "");
+        }
+
+        #[test]
+        fn leading_comment() {
+            let input = InputSpan::new_extra("# comment\nparam = 1", Config::default());
+            let (rest, matched) = start_of_file(input).expect("should parse leading comment");
+            assert_eq!(rest.fragment(), &"param = 1");
+            assert_eq!(matched.lexeme_str, "");
+        }
+
+        #[test]
+        fn leading_whitespace_before_comment() {
+            let input = InputSpan::new_extra("   # comment\nparam = 1", Config::default());
+            let (rest, matched) =
+                start_of_file(input).expect("should parse whitespace before comment");
+            assert_eq!(rest.fragment(), &"param = 1");
+            assert_eq!(matched.lexeme_str, "");
+        }
+
+        #[test]
+        fn multiple_leading_end_of_lines() {
+            let input = InputSpan::new_extra("\n\n# foo\n\nparam = 1", Config::default());
+            let (rest, matched) =
+                start_of_file(input).expect("should parse multiple leading end of lines");
+            assert_eq!(rest.fragment(), &"param = 1");
+            assert_eq!(matched.lexeme_str, "");
         }
     }
 


### PR DESCRIPTION
Previously, models that started with whitespace would fail to parse.

```
    ~ My model that does things
#^^^ this whitespace causes an error

# ... parameters
```

The error is fixed in this PR.