### PR TITLE
Add Alfred review policy

### DIFF
--- a/.github/review.yaml
+++ b/.github/review.yaml
@@ -1,0 +1,23 @@
+$schema: https://raw.githubusercontent.com/careweather/standards/main/alfred/schemas/review-config.schema.json
+version: 1
+mode: shadow
+targetBranches:
+  - main
+maxFilesWithoutReview: 20
+requireAuthorOwnership: true
+protectedPaths:
+  - .github/**
+  - .github/review.yaml
+  - alfred/**
+  - governance/**
+protectedFallbackReviewers: []
+relatedRepositories:
+  - careweather/nest
+  - careweather/veery
+codeownersCleanup:
+  enabled: false
+review:
+  startWhenReady: true
+  debounceSeconds: 120
+  requireFixConfirmation: true
+  suppressNewLowMediumDuringConfirmation: true


### PR DESCRIPTION
## Problem
Alfred needs versioned repository policy before organization-wide shadow reviews can start.

## Approach
Add `.github/review.yaml` in shadow mode with the shared 20-file and ownership defaults plus Nest/Veery context.

## Results
The file changes no runtime behavior while Alfred remains in shadow mode.

## Recommendations and Questions
Merge after [careweather/standards#3](https://github.com/careweather/standards/pull/3) is ready. Keep `mode: shadow` until evaluation gates pass.

## Check before publishing
- [x] Shared defaults applied
- [x] Alfred writes and auto-approval remain disabled

Made with [Cursor](https://cursor.com)