### PR TITLE
Enable Alfred approval policy

### DIFF
--- a/.github/review.yaml
+++ b/.github/review.yaml
@@ -1,23 +1,2 @@
 $schema: https://raw.githubusercontent.com/careweather/standards/main/alfred/schemas/review-config.schema.json
 version: 1
-mode: shadow
-targetBranches:
-  - main
-maxFilesWithoutReview: 20
-requireAuthorOwnership: true
-protectedPaths:
-  - .github/**
-  - .github/review.yaml
-  - alfred/**
-  - governance/**
-protectedFallbackReviewers: []
-relatedRepositories:
-  - careweather/nest
-  - careweather/veery
-codeownersCleanup:
-  enabled: false
-review:
-  startWhenReady: true
-  debounceSeconds: 120
-  requireFixConfirmation: true
-  suppressNewLowMediumDuringConfirmation: true


### PR DESCRIPTION
## Problem
This repository is still pinned to silent shadow mode.

## Approach
Inherit the tested centralized Alfred approval and bounded fix-proposal policy.

## Results
New eligible pull requests receive visible reviews and approval decisions; protected paths still require humans.

## Recommendations
Keep fix PR merge and branch deletion disabled.

Made with [Cursor](https://cursor.com)