### PR TITLE
Block new Semgrep findings

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -12,20 +12,47 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     container:
-      image: semgrep/semgrep:1.175.0
+      image: semgrep/semgrep:1.175.0@sha256:b94b53d02fd4a022f9eac4e2af1380f5c3c4c21400e79d3336bdff1d1db5e796
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
+
+      - name: Fetch reviewed Semgrep rules
+        env:
+          SEMGREP_PACKS: |
+            rust 3a769ea74a51ff71b66adc8de48af2baf7623db8940b08cba190b03cb7259ae7
+            typescript 63fbcca1826e787ca43282bf139ccec16745ad6551c87850b9ccee9ca9f98c0b
+            python 31c1dfa46e8ddd97f9ac98c607ddd77b20a2c3356d7ec987359961d47ec27035
+        run: |
+          python3 - <<'PY'
+          import hashlib
+          import os
+          from pathlib import Path
+          from urllib.parse import urlparse
+          from urllib.request import urlopen
+
+          output = Path(os.environ["RUNNER_TEMP"]) / "semgrep-rules"
+          output.mkdir(parents=True, exist_ok=True)
+          for entry in os.environ["SEMGREP_PACKS"].splitlines():
+              name, expected = entry.split()
+              with urlopen(f"https://semgrep.dev/c/p/{name}", timeout=30) as response:
+                  if urlparse(response.geturl()).hostname != "semgrep.dev":
+                      raise RuntimeError("Semgrep rules redirected outside semgrep.dev")
+                  content = response.read()
+              if hashlib.sha256(content).hexdigest() != expected:
+                  raise RuntimeError(f"Semgrep rules changed for {name}")
+              (output / f"{name}.yml").write_bytes(content)
+          PY
 
       - name: Scan changed code
         env:
           SEMGREP_BASELINE_COMMIT: ${{ github.event.pull_request.base.sha }}
         run: |
           semgrep scan \
-            --config "p/rust" \
-            --config "p/typescript" \
-            --config "p/python" \
+            --config "$RUNNER_TEMP/semgrep-rules/rust.yml" \
+            --config "$RUNNER_TEMP/semgrep-rules/typescript.yml" \
+            --config "$RUNNER_TEMP/semgrep-rules/python.yml" \
             --baseline-commit "$SEMGREP_BASELINE_COMMIT" \
             --exclude "target" \
             --exclude "node_modules" \
@@ -36,5 +63,6 @@ jobs:
             --jobs 2 \
             --oss-only \
             --metrics=off \
+            --strict \
             --error \
             .

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,40 @@
+name: Semgrep
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    name: Semgrep / changed findings
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    container:
+      image: semgrep/semgrep:1.175.0
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Scan changed code
+        env:
+          SEMGREP_BASELINE_COMMIT: ${{ github.event.pull_request.base.sha }}
+        run: |
+          semgrep scan \
+            --config "p/rust" \
+            --config "p/typescript" \
+            --config "p/python" \
+            --baseline-commit "$SEMGREP_BASELINE_COMMIT" \
+            --exclude "target" \
+            --exclude "node_modules" \
+            --exclude "dist" \
+            --exclude "out" \
+            --exclude "coverage" \
+            --exclude "src/oneil_wasm/pkg" \
+            --jobs 2 \
+            --oss-only \
+            --metrics=off \
+            --error \
+            .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,24 @@ pull requests:
 - **Unused dependencies** — `cargo udeps` on nightly to catch crates that are
   declared but unused.
 
+### Semgrep (pull requests)
+
+[`.github/workflows/semgrep.yml`](.github/workflows/semgrep.yml) scans Rust,
+TypeScript, React, and Python changes with reviewed public Semgrep rules. It
+compares the pull request with its exact base commit. Existing findings do not
+block unrelated changes.
+
+To reproduce the scan locally:
+
+1. Install the pinned CLI with `pipx install semgrep==1.175.0`.
+2. Fetch the public `p/rust`, `p/typescript`, and `p/python` configurations.
+3. Verify their SHA-256 values against the values in the workflow.
+4. Run `semgrep scan` with those local files, `--strict`, `--error`, and
+   `--baseline-commit "$(git merge-base HEAD origin/main)"`.
+
+The workflow uses only read access. It does not require a Semgrep account or
+token.
+
 ### Coding standards review (advisory)
 
 [`.github/workflows/coding-standards-review.yml`](.github/workflows/coding-standards-review.yml)


### PR DESCRIPTION
## Problem

Oneil has Rust, TypeScript, React, and Python code but no deterministic Semgrep security check.

## Approach

- run reviewed public `p/rust`, `p/typescript`, and `p/python` rule bytes
- pin the scanner image, checkout action, and each semgrep.dev configuration hash
- compare each pull request with its exact base SHA and fail on parser warnings
- document the local equivalent in `CONTRIBUTING.md`

## Results

- 236 public rules validate and scan without errors
- all four public React rules are already present in `p/typescript`
- a full report-only scan found one existing Rust `unsafe` finding in `load_python_venv.rs`
- the current GitHub Semgrep, native CI, and Alfred checks pass
- mixed-language fixtures exit 1 when new and 0 when present in the baseline

## Recommendations

Triage the existing finding separately. This PR does not suppress it or duplicate the React pack.